### PR TITLE
Fix README typo and provide uri used when agent api request fails

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -129,7 +129,7 @@ To deploy your application to CloudHub:
         <extensions>true</extensions>
     </plugin>
     <plugin>
-        <groupId>org.mule.toos</groupId>
+        <groupId>org.mule.tools</groupId>
         <artifactId>mule-maven-plugin</artifactId>
         <version>2.0-RC1</version>
         <configuration>
@@ -205,7 +205,7 @@ You can make the plugin deploy to an existing Mule server, using the API provide
         <extensions>true</extensions>
     </plugin>
     <plugin>
-        <groupId>org.mule.toos</groupId>
+        <groupId>org.mule.tools</groupId>
         <artifactId>mule-maven-plugin</artifactId>
         <version>2.0-RC1</version>
         <configuration>

--- a/src/main/java/org/mule/tools/mule/ApiException.java
+++ b/src/main/java/org/mule/tools/mule/ApiException.java
@@ -23,6 +23,11 @@ public class ApiException extends RuntimeException
 
     }
 
+    public ApiException(Response response, String uri)
+    {
+        this(uri, response.getStatusInfo().getStatusCode(), response.getStatusInfo().getReasonPhrase());
+    }
+
     public ApiException(Response response)
     {
         this(response.readEntity(String.class), response.getStatusInfo().getStatusCode(), response.getStatusInfo().getReasonPhrase());

--- a/src/main/java/org/mule/tools/mule/agent/AgentApi.java
+++ b/src/main/java/org/mule/tools/mule/agent/AgentApi.java
@@ -36,7 +36,7 @@ public class AgentApi extends AbstractApi
 
         if (response.getStatus() != 202) // Created
         {
-            throw new ApiException(response);
+            throw new ApiException(response, uri + APPLICATIONS_PATH + applicationName);
         }
     }
 
@@ -46,7 +46,7 @@ public class AgentApi extends AbstractApi
 
         if (response.getStatus() != 202)
         {
-            throw new ApiException(response);
+            throw new ApiException(response, uri + APPLICATIONS_PATH + applicationName);
         }
     }
 


### PR DESCRIPTION
**Fix README typo:** - d6e89fc5c638e188d4c4793c5df3881fbacb158d
Some of the pom examples are missing a `l` in their groupid for the value `org.mule.tools`

**Provide uri when agent api request fails:** - c294532625089c98e2871235b91a003d50cb8399
When an API request to the agent api fails a user receives:
```
[ERROR] Failure: 405 HTTP method PUT is not supported by this URL:
```
This commit demonstrates a exception returned that contains the uri. This way the user has better context on why the api call failed.
```
[ERROR] Failure: 405 HTTP method PUT is not supported by this URL: http://52.25.43.249:9999/breakit/mule/applications/maven-project-beep
```