### PR TITLE
MMP-119 Update javadoc plugin to work on Java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,12 +349,18 @@
         </profile>
         <profile>
             <id>release</id>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>2.10</version>
+                        <configuration>
+                            <additionalparam>${javadoc.opts}</additionalparam>
+                        </configuration>
                         <executions>
                             <execution>
                                 <goals>


### PR DESCRIPTION
When upgrading the code to build on Java8, the javadoc tool on this version introduce the doclint feature that performs validations under the javadoc comments. This cause the build to fail when doing the release. By setting this property, we are disabling the validations.