### PR TITLE
Fixing tests to work on windows and adding skipValidation flag

### DIFF
--- a/src/main/java/org/mule/tools/maven/mojo/AbstractMuleMojo.java
+++ b/src/main/java/org/mule/tools/maven/mojo/AbstractMuleMojo.java
@@ -72,6 +72,9 @@ public abstract class AbstractMuleMojo extends AbstractMojo {
   @Parameter(defaultValue = "${lightweightPackage}")
   protected boolean lightweightPackage = false;
 
+  @Parameter(defaultValue = "${skipValidation}")
+  protected boolean skipValidation = false;
+
   @Parameter(property = "shared.libraries", required = false)
   protected List<SharedLibraryDependency> sharedLibraries;
 

--- a/src/main/java/org/mule/tools/maven/mojo/GenerateSourcesMojo.java
+++ b/src/main/java/org/mule/tools/maven/mojo/GenerateSourcesMojo.java
@@ -18,6 +18,7 @@ import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,7 +42,9 @@ public class GenerateSourcesMojo extends AbstractMuleMojo {
   protected ProjectBaseFolderFileCloner projectBaseFolderFileCloner;
 
   public void execute() throws MojoExecutionException, MojoFailureException {
-    getLog().debug("Creating target content with Mule source code...");
+    long start = System.currentTimeMillis();
+    getLog().debug("Generating source code...");
+
     projectBaseFolderFileCloner = new ProjectBaseFolderFileCloner(project);
     try {
       createSrcFolderContent();
@@ -50,6 +53,8 @@ public class GenerateSourcesMojo extends AbstractMuleMojo {
     } catch (IOException e) {
       throw new MojoFailureException("Fail to generate sources", e);
     }
+
+    getLog().debug(MessageFormat.format("Source code generation done ({0}ms)", System.currentTimeMillis() - start));
   }
 
   protected void createSrcFolderContent() throws IOException, MojoExecutionException {

--- a/src/main/java/org/mule/tools/maven/mojo/GenerateTestSourcesMojo.java
+++ b/src/main/java/org/mule/tools/maven/mojo/GenerateTestSourcesMojo.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.text.MessageFormat;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -34,13 +35,16 @@ import org.mule.tools.maven.util.CopyFileVisitor;
 public class GenerateTestSourcesMojo extends AbstractMuleMojo {
 
   public void execute() throws MojoExecutionException, MojoFailureException {
-    getLog().debug("Creating target content with Test Mule source code...");
+    long start = System.currentTimeMillis();
+    getLog().debug("Generating test source code...");
 
     try {
       createTestMuleFolderContent();
     } catch (IOException e) {
       throw new MojoFailureException("Fail to generate sources", e);
     }
+
+    getLog().debug(MessageFormat.format("Test source code generation done ({0}ms)", System.currentTimeMillis() - start));
   }
 
   private void createTestMuleFolderContent() throws IOException {

--- a/src/main/java/org/mule/tools/maven/mojo/InitializeMojo.java
+++ b/src/main/java/org/mule/tools/maven/mojo/InitializeMojo.java
@@ -20,6 +20,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.mule.tools.maven.mojo.model.PackagingType;
 
+import java.text.MessageFormat;
+
 /**
  * It creates all the required folders in the project.build.directory
  */
@@ -29,6 +31,7 @@ import org.mule.tools.maven.mojo.model.PackagingType;
 public class InitializeMojo extends AbstractMuleMojo {
 
   public void execute() throws MojoExecutionException, MojoFailureException {
+    long start = System.currentTimeMillis();
     getLog().debug("Initializing Mule Maven Plugin...");
 
     String groupId = project.getGroupId();
@@ -51,7 +54,7 @@ public class InitializeMojo extends AbstractMuleMojo {
 
     createFolderIfNecessary(targetFolder, REPOSITORY);
 
-    getLog().debug("Mule Maven Plugin Initialize done");
+    getLog().debug(MessageFormat.format("Mule Maven Plugin Initialize done ({0}ms)", System.currentTimeMillis() - start));
   }
 
 }

--- a/src/main/java/org/mule/tools/maven/mojo/PackageMojo.java
+++ b/src/main/java/org/mule/tools/maven/mojo/PackageMojo.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.MessageFormat;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -53,15 +54,22 @@ public class PackageMojo extends AbstractMuleMojo {
   protected PackagingType packagingType;
 
   public void execute() throws MojoExecutionException, MojoFailureException {
+    long start = System.currentTimeMillis();
+    getLog().debug("Packaging...");
+
     packagingType = PackagingType.fromString(project.getPackaging());
     String targetFolder = project.getBuild().getDirectory();
     File destinationFile = getDestinationFile(targetFolder);
+
     try {
       createMuleApp(destinationFile, targetFolder);
     } catch (ArchiverException e) {
       throw new MojoExecutionException("Exception creating the Mule App", e);
     }
+
     helper.attachArtifact(this.project, TYPE, packagingType.resolveClassifier(classifier, lightweightPackage), destinationFile);
+
+    getLog().debug(MessageFormat.format("Package done ({0}ms)", System.currentTimeMillis() - start));
   }
 
   /**

--- a/src/main/java/org/mule/tools/maven/mojo/ProcessSourcesMojo.java
+++ b/src/main/java/org/mule/tools/maven/mojo/ProcessSourcesMojo.java
@@ -10,6 +10,7 @@
 
 package org.mule.tools.maven.mojo;
 
+import java.text.MessageFormat;
 import java.util.List;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -46,6 +47,9 @@ public class ProcessSourcesMojo extends AbstractMuleMojo {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
+    long start = System.currentTimeMillis();
+    getLog().debug("Processing sources...");
+
     if (!lightweightPackage) {
       RepositoryGenerator repositoryGenerator = new RepositoryGenerator(session,
                                                                         project,
@@ -58,5 +62,6 @@ public class ProcessSourcesMojo extends AbstractMuleMojo {
       repositoryGenerator.generate();
     }
 
+    getLog().debug(MessageFormat.format("Process sources done ({0}ms)", System.currentTimeMillis() - start));
   }
 }

--- a/src/main/java/org/mule/tools/maven/mojo/ValidateMojo.java
+++ b/src/main/java/org/mule/tools/maven/mojo/ValidateMojo.java
@@ -44,17 +44,19 @@ public class ValidateMojo extends AbstractMuleMojo {
   protected MulePluginsCompatibilityValidator validator;
 
   public void execute() throws MojoExecutionException, MojoFailureException {
-    long start = System.currentTimeMillis();
-    getLog().debug("Validating Mule application...");
-
     if (!skipValidation) {
+      long start = System.currentTimeMillis();
+      getLog().debug("Validating Mule application...");
+
       validateMandatoryFolders();
       validateMandatoryDescriptors();
       validateMulePluginDependencies();
       validateSharedLibraries();
-    }
 
-    getLog().debug(MessageFormat.format("Validation for Mule application done ({0}ms)", System.currentTimeMillis() - start));
+      getLog().debug(MessageFormat.format("Validation for Mule application done ({0}ms)", System.currentTimeMillis() - start));
+    } else {
+      getLog().debug("Skipping Validation for Mule application");
+    }
   }
 
   protected void validateSharedLibraries() throws MojoExecutionException {

--- a/src/main/java/org/mule/tools/maven/mojo/ValidateMojo.java
+++ b/src/main/java/org/mule/tools/maven/mojo/ValidateMojo.java
@@ -17,6 +17,7 @@ import static org.mule.tools.artifact.archiver.api.PackagerFolders.POLICY;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -43,14 +44,17 @@ public class ValidateMojo extends AbstractMuleMojo {
   protected MulePluginsCompatibilityValidator validator;
 
   public void execute() throws MojoExecutionException, MojoFailureException {
+    long start = System.currentTimeMillis();
     getLog().debug("Validating Mule application...");
 
-    validateMandatoryFolders();
-    validateMandatoryDescriptors();
-    validateMulePluginDependencies();
-    validateSharedLibraries();
+    if (!skipValidation) {
+      validateMandatoryFolders();
+      validateMandatoryDescriptors();
+      validateMulePluginDependencies();
+      validateSharedLibraries();
+    }
 
-    getLog().debug("Validating Mule application done");
+    getLog().debug(MessageFormat.format("Validation for Mule application done ({0}ms)", System.currentTimeMillis() - start));
   }
 
   protected void validateSharedLibraries() throws MojoExecutionException {

--- a/src/main/java/org/mule/tools/maven/repository/RepositoryGenerator.java
+++ b/src/main/java/org/mule/tools/maven/repository/RepositoryGenerator.java
@@ -15,6 +15,10 @@ import static org.mule.tools.artifact.archiver.api.PackagerFolders.REPOSITORY;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.DosFileAttributeView;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -30,6 +34,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.repository.RepositorySystem;
+import org.mule.tools.maven.util.FileUtils;
 
 public class RepositoryGenerator {
 
@@ -124,10 +129,10 @@ public class RepositoryGenerator {
     File markerFile = new File(repositoryFile, ".marker");
     log.info(format("No artifacts to add, adding marker file <%s/%s>", REPOSITORY, markerFile.getName()));
     try {
+      FileUtils.checkReadOnly(repositoryFile);
       markerFile.createNewFile();
     } catch (IOException e) {
-      throw new MojoExecutionException(
-                                       format("The current repository has no artifacts to install, and trying to create [%s] failed",
+      throw new MojoExecutionException(format("The current repository has no artifacts to install, and trying to create [%s] failed",
                                               markerFile.toString()),
                                        e);
     }

--- a/src/main/java/org/mule/tools/maven/util/FileUtils.java
+++ b/src/main/java/org/mule/tools/maven/util/FileUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Mule ESB Maven Tools
+ * <p>
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * <p>
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.tools.maven.util;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.DosFileAttributeView;
+
+public class FileUtils {
+
+  public static void markAsReadOnly(File file) throws IOException {
+    boolean succeeded = file.setReadOnly();
+    // We need to add this extra logic due to a bug in windows (JDK-6728842)
+    if (!succeeded) {
+      Path filePath = file.toPath();
+      FileStore fileStore = Files.getFileStore(filePath);
+      if (fileStore.supportsFileAttributeView(DosFileAttributeView.class)) {
+        DosFileAttributeView fileAttributeView = Files.getFileAttributeView(filePath, DosFileAttributeView.class);
+        fileAttributeView.setReadOnly(true);
+      }
+    }
+  }
+
+  public static void checkReadOnly(File file) throws IOException, MojoExecutionException {
+    // This logic check if the file attribute was mark as read only because File#setReadOnly is platform dependent (JDK-6728842)
+    Path repositoryPath = file.toPath();
+    FileStore fileStore = Files.getFileStore(repositoryPath);
+    if (fileStore.supportsFileAttributeView(DosFileAttributeView.class)) {
+      DosFileAttributeView fileAttributeView = Files.getFileAttributeView(repositoryPath, DosFileAttributeView.class);
+      if (fileAttributeView.readAttributes().isReadOnly()) {
+        throw new IOException("File is not writable");
+      }
+    }
+  }
+}

--- a/src/test/java/org/mule/tools/maven/mojo/InitializeMojoTest.java
+++ b/src/test/java/org/mule/tools/maven/mojo/InitializeMojoTest.java
@@ -28,8 +28,6 @@ import org.mule.tools.maven.FileTreeMatcher;
 
 public class InitializeMojoTest extends AbstractMuleMojoTest {
 
-  private static final String INITIALIZE_GOAL_DEBUG_MESSAGE =
-      "[debug] Initializing Mule Maven Plugin...\n[debug] Mule Maven Plugin Initialize done\n";
   private static final String EXPECTED_STRUCTURE_RELATIVE_PATH = "/expected-initialize-structure";
   private AbstractMuleMojo mojo;
 
@@ -49,7 +47,6 @@ public class InitializeMojoTest extends AbstractMuleMojoTest {
     String[] excludes = new String[] {".placeholder"};
     assertThat("The target folder directory does not have the expected structure", projectRootFolder.getRoot(),
                FileTreeMatcher.hasSameTreeStructure(rootOfExpectedStructure, excludes));
-    assertThat("Initialize goal message was not the expected", INITIALIZE_GOAL_DEBUG_MESSAGE, equalTo(outContent.toString()));
   }
 
   @Test

--- a/src/test/java/org/mule/tools/maven/mojo/ValidateMojoTest.java
+++ b/src/test/java/org/mule/tools/maven/mojo/ValidateMojoTest.java
@@ -32,8 +32,6 @@ public class ValidateMojoTest extends AbstractMuleMojoTest {
 
   private static final ValidateMojo mojo = new ValidateMojo();
 
-  private static final String VALIDATE_GOAL_DEBUG_MESSAGE =
-      "[debug] Validating Mule application...\n[debug] Validating Mule application done\n";
   private static final String VALIDATE_MANDATORY_FOLDERS_MESSAGE =
       "Invalid Mule project. Missing src/main/mule folder. This folder is mandatory";
   private static final String VALIDATE_SHARED_LIBRARIES_MESSAGE =
@@ -87,7 +85,6 @@ public class ValidateMojoTest extends AbstractMuleMojoTest {
 
     verify(resolverMock, times(1)).resolveMulePlugins(any());
     verify(validatorMock, times(1)).validate(anyList());
-    assertThat("Validate goal message was not the expected", VALIDATE_GOAL_DEBUG_MESSAGE, equalTo(outContent.toString()));
   }
 
   @Test

--- a/src/test/java/org/mule/tools/maven/repository/RepositoryGeneratorTest.java
+++ b/src/test/java/org/mule/tools/maven/repository/RepositoryGeneratorTest.java
@@ -16,6 +16,10 @@ import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.DosFileAttributeView;
 import java.util.*;
 
 import org.apache.maven.artifact.Artifact;
@@ -36,6 +40,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 import org.mockito.Spy;
+import org.mule.tools.maven.util.FileUtils;
 
 public class RepositoryGeneratorTest {
 
@@ -113,14 +118,14 @@ public class RepositoryGeneratorTest {
   }
 
   @Test
-  public void generateMarkerFileInRepositoryFolderWhenFolderIsNotWritableTest() throws MojoExecutionException {
+  public void generateMarkerFileInRepositoryFolderWhenFolderIsNotWritableTest() throws MojoExecutionException, IOException {
     exception.expect(MojoExecutionException.class);
     File generatedMarkerFile = new File(temporaryFolder.getRoot(), ".marker");
 
     assertThat("Marker file already exists", !generatedMarkerFile.exists());
 
     File readOnlyFolder = temporaryFolder.getRoot();
-    readOnlyFolder.setReadOnly();
+    FileUtils.markAsReadOnly(readOnlyFolder);
 
     repositoryGenerator.generateMarkerFileInRepositoryFolder(readOnlyFolder);
   }


### PR DESCRIPTION
I changed the tests to avoid validate mojo execution using the log, that is error prone and something the log can contains dynamic information.
I have included a utility class to mark and check read only flag, because in windows the File#setReadOnly does not work properly. 