### PR TITLE
Include IT to report coverage and update some modules names for the report

### DIFF
--- a/mule-artifact-it/mule-deployer-it/pom.xml
+++ b/mule-artifact-it/mule-deployer-it/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mule-deployer-it</artifactId>
+    <name>Mule Deployer Integration Tests</name>
 
     <properties>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>

--- a/mule-artifact-it/mule-deployer-it/src/test/java/integrationTests/mojo/SettingsConfigurator.java
+++ b/mule-artifact-it/mule-deployer-it/src/test/java/integrationTests/mojo/SettingsConfigurator.java
@@ -31,10 +31,18 @@ public interface SettingsConfigurator {
     }
   }
 
+  default void setMavenOpts(Verifier verifier) {
+    String mavenOpts = System.getProperty("argLine");
+    if (mavenOpts != null) {
+      verifier.setEnvironmentVariable("MAVEN_OPTS", mavenOpts);
+    }
+  }
+
   default Verifier buildVerifier(File projectBaseDirectory) throws VerificationException {
     Verifier verifier = new Verifier(projectBaseDirectory.getAbsolutePath());
     setSettings(verifier);
     setMuleMavenPluginVersion(verifier);
+    setMavenOpts(verifier);
     return verifier;
   }
 }

--- a/mule-artifact-it/mule-packager-it/pom.xml
+++ b/mule-artifact-it/mule-packager-it/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mule-packager-it</artifactId>
+    <name>Mule Packager Integration Tests</name>
 
     <properties>
         <licensePath>../../LICENSE_HEADER.txt</licensePath>

--- a/mule-artifact-it/mule-packager-it/src/test/java/integrationTests/mojo/SettingsConfigurator.java
+++ b/mule-artifact-it/mule-packager-it/src/test/java/integrationTests/mojo/SettingsConfigurator.java
@@ -32,10 +32,10 @@ public interface SettingsConfigurator {
   }
 
   default void setMavenOpts(Verifier verifier) {
-     String mavenOpts = System.getProperty("argLine");
-     if (mavenOpts != null) {
-          verifier.setEnvironmentVariable("MAVEN_OPTS", mavenOpts);
-     }
+    String mavenOpts = System.getProperty("argLine");
+    if (mavenOpts != null) {
+      verifier.setEnvironmentVariable("MAVEN_OPTS", mavenOpts);
+    }
   }
 
   default Verifier buildVerifier(File projectBaseDirectory) throws VerificationException {

--- a/mule-artifact-it/mule-packager-it/src/test/java/integrationTests/mojo/SettingsConfigurator.java
+++ b/mule-artifact-it/mule-packager-it/src/test/java/integrationTests/mojo/SettingsConfigurator.java
@@ -31,10 +31,18 @@ public interface SettingsConfigurator {
     }
   }
 
+  default void setMavenOpts(Verifier verifier) {
+     String mavenOpts = System.getProperty("argLine");
+     if (mavenOpts != null) {
+          verifier.setEnvironmentVariable("MAVEN_OPTS", mavenOpts);
+     }
+  }
+
   default Verifier buildVerifier(File projectBaseDirectory) throws VerificationException {
     Verifier verifier = new Verifier(projectBaseDirectory.getAbsolutePath());
     setSettings(verifier);
     setMuleMavenPluginVersion(verifier);
+    setMavenOpts(verifier);
     return verifier;
   }
 }

--- a/mule-artifact-it/pom.xml
+++ b/mule-artifact-it/pom.xml
@@ -9,6 +9,7 @@
 
     <artifactId>mule-artifact-it</artifactId>
     <packaging>pom</packaging>
+    <name>Mule Maven Plugin Integration Tests</name>
 
 
     <properties>

--- a/mule-classloader-model/pom.xml
+++ b/mule-classloader-model/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mule-classloader-model</artifactId>
-    <name>Mule Packager</name>
+    <name>Mule Class Loader Model</name>
 
     <properties>
         <licensePath>../LICENSE_HEADER.txt</licensePath>

--- a/mule-deployer/pom.xml
+++ b/mule-deployer/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>mule-deployer</artifactId>
+    <name>Mule Deployer Mojo</name>
 
     <properties>
         <licensePath>../LICENSE_HEADER.txt</licensePath>

--- a/mule-maven-plugin/pom.xml
+++ b/mule-maven-plugin/pom.xml
@@ -9,7 +9,7 @@
 
     <artifactId>mule-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <name>Mule Maven Plugin</name>
+    <name>Mule Packager Mojo</name>
 
     <description>
         Maven plugin to deploy Mule applications to different kinds of servers: Standalone (both Community and Enterprise), Clustered, Anypoint Runtime Manager and CloudHub.

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
                         <lineEnding>LF</lineEnding>
                         <aggregator>false</aggregator>
                         <executionRoot>true</executionRoot>
-                        <skipFormatting>${skipTests}</skipFormatting>
+                        <skipFormatting>${skipVerifications}</skipFormatting>
                     </configuration>
                     <executions>
                         <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>mule-artifact-tools</artifactId>
     <version>3.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>Mule Artifact Tools</name>
+    <name>Mule Maven Plugin</name>
     <url>https://github.com/mulesoft/mule-maven-plugin</url>
 
     <modules>
@@ -89,6 +89,9 @@
 
         <licensePath>LICENSE_HEADER.txt</licensePath>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
+
+        <skipTests>false</skipTests>
+        <jacocoAgentArgLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.maven.plugin.version}/org.jacoco.agent-${jacoco.maven.plugin.version}-runtime.jar=destfile='${session.executionRootDirectory}/target/jacoco.exec'</jacocoAgentArgLine>
     </properties>
 
 
@@ -311,6 +314,7 @@
                                 <outputDirectory>${project.build.directory}</outputDirectory>
                             </artifactItem>
                         </artifactItems>
+                        <skip>${skipTests}</skip>
                     </configuration>
                     <executions>
                         <execution>
@@ -366,7 +370,7 @@
                         <lineEnding>LF</lineEnding>
                         <aggregator>false</aggregator>
                         <executionRoot>true</executionRoot>
-                        <skipFormatting>${skipVerifications}</skipFormatting>
+                        <skipFormatting>${skipTests}</skipFormatting>
                     </configuration>
                     <executions>
                         <execution>
@@ -382,9 +386,11 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.plugin.version}</version>
                     <configuration>
+                        <argLine>${jacocoAgentArgLine}</argLine>
                         <systemPropertyVariables>
                             <mule.maven.plugin.version>${project.version}</mule.maven.plugin.version>
                             <mule.home.test>${project.build.directory}</mule.home.test>
+                            <argLine>-javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.maven.plugin.version}/org.jacoco.agent-${jacoco.maven.plugin.version}-runtime.jar=destfile=${session.executionRootDirectory}/target/jacoco-it.exec</argLine>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
-Rename modules to display correctly on reports
-IT will report code coverage
-Get value of skipTests and pass it to maven-dependency-plugin, that way if you skip tests, the standalone won't be downloaded.