### PR TITLE
 Fixes wrong mule-site-plugin version

### DIFF
--- a/mule-artifact-it/mule-packager-it/src/test/resources/expected-classloader-model-project/temp/META-INF/maven/org.apache.maven.plugin.my.unit/empty-classloader-model-project/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/expected-classloader-model-project/temp/META-INF/maven/org.apache.maven.plugin.my.unit/empty-classloader-model-project/pom.xml
@@ -301,7 +301,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>default-site</id>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/expected-compile-structure/temp/META-INF/maven/org.apache.maven.plugin.my.unit/empty-compile-project/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/expected-compile-structure/temp/META-INF/maven/org.apache.maven.plugin.my.unit/empty-compile-project/pom.xml
@@ -280,7 +280,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>default-site</id>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/expected-generate-test-sources-structure/temp/META-INF/maven/org.apache.maven.plugin.my.unit/empty-generate-sources-project/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/expected-generate-test-sources-structure/temp/META-INF/maven/org.apache.maven.plugin.my.unit/empty-generate-sources-project/pom.xml
@@ -280,7 +280,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>default-site</id>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/expected-package-app-shared-libraries/temp/META-INF/maven/org.apache.maven.plugin.my.unit/validate-goal-project/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/expected-package-app-shared-libraries/temp/META-INF/maven/org.apache.maven.plugin.my.unit/validate-goal-project/pom.xml
@@ -390,7 +390,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>default-site</id>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/expected-package-policy-structure/temp/META-INF/maven/org.apache.maven.plugin.my.unit/empty-install-policy-project/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/expected-package-policy-structure/temp/META-INF/maven/org.apache.maven.plugin.my.unit/empty-install-policy-project/pom.xml
@@ -280,7 +280,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>default-site</id>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/expected-package-structure/temp/META-INF/maven/org.apache.maven.plugin.my.unit/empty-package-project/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/expected-package-structure/temp/META-INF/maven/org.apache.maven.plugin.my.unit/empty-package-project/pom.xml
@@ -288,7 +288,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>default-site</id>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/expected-process-sources-structure/temp/META-INF/maven/org.apache.maven.plugin.my.unit/empty-process-sources-project/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/expected-process-sources-structure/temp/META-INF/maven/org.apache.maven.plugin.my.unit/empty-process-sources-project/pom.xml
@@ -288,7 +288,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>default-site</id>

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/MuleLifecycleMapping.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/MuleLifecycleMapping.java
@@ -49,7 +49,7 @@ public class MuleLifecycleMapping implements LifecycleMapping, ProjectLifecycleM
   private static final String MAVEN_SUREFIRE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-surefire-plugin:2.19.1";
   private static final String MAVEN_INSTALL_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-install-plugin:2.5.2";
   private static final String MAVEN_DEPLOY_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-deploy-plugin:2.8.2";
-  private static final String MAVEN_SITE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-site-plugin:3.6.1";
+  private static final String MAVEN_SITE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-site-plugin:3.7.1";
 
   @Override
   public List<String> getOptionalMojos(String lifecycle) {


### PR DESCRIPTION
There is no version 3.6.1 of maven-site-plugin.  https://maven.apache.org/plugins/maven-site-plugin/history.html

Currently running `mvn dependency:tree` with the mule-maven-plugin produces the following:
> [WARNING] The POM for org.apache.maven.plugins:maven-site-plugin:jar:3.6.1 is missing, no dependency information available

Not sure if 3.7.1 is what is really needed, but it's the latest.
