### PR TITLE
Adds configuration to use Bearer Token for authentication

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/client/AbstractMuleClient.java
+++ b/mule-deployer/src/main/java/org/mule/tools/client/AbstractMuleClient.java
@@ -300,8 +300,10 @@ public abstract class AbstractMuleClient extends AbstractClient {
         case user:
           Credentials creds = (Credentials) credentials;
           bearerToken = authenticationServiceClient.getBearerToken(creds);
+          break;
         case token:
           bearerToken = ((AnypointToken) credentials).getToken();
+          break;
       }
     }
 

--- a/mule-deployer/src/main/java/org/mule/tools/client/AbstractMuleClient.java
+++ b/mule-deployer/src/main/java/org/mule/tools/client/AbstractMuleClient.java
@@ -21,7 +21,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.apache.commons.lang3.StringUtils;
 
 import org.mule.tools.client.core.AbstractClient;
 import org.mule.tools.client.arm.model.Environment;
@@ -30,11 +29,12 @@ import org.mule.tools.client.arm.model.Organization;
 import org.mule.tools.client.arm.model.User;
 import org.mule.tools.client.arm.model.UserInfo;
 import org.mule.tools.client.authentication.AuthenticationServiceClient;
+import org.mule.tools.client.authentication.model.AnypointCredential;
+import org.mule.tools.client.authentication.model.AnypointToken;
 import org.mule.tools.client.authentication.model.Credentials;
 import org.mule.tools.model.anypoint.AnypointDeployment;
 import org.mule.tools.utils.DeployerLog;
 
-import com.google.gson.Gson;
 
 public abstract class AbstractMuleClient extends AbstractClient {
 
@@ -51,10 +51,12 @@ public abstract class AbstractMuleClient extends AbstractClient {
   public static final String USER = "user";
   public static final String ID = "id";
 
+  public static final String UNAUTHORIZED = "unauthorized";
+
   protected String baseUri;
 
   private String bearerToken;
-  private Credentials credentials;
+  private AnypointCredential credentials;
   protected AuthenticationServiceClient authenticationServiceClient;
 
   // TODO MMP-302
@@ -68,7 +70,11 @@ public abstract class AbstractMuleClient extends AbstractClient {
     super(log);
     this.baseUri = anypointDeployment.getUri();
 
-    this.credentials = new Credentials(anypointDeployment.getUsername(), anypointDeployment.getPassword());
+    if (!isEmpty(anypointDeployment.getAuthToken())) {
+      this.credentials = new AnypointToken(anypointDeployment.getAuthToken());
+    } else {
+      this.credentials = new Credentials(anypointDeployment.getUsername(), anypointDeployment.getPassword());
+    }
 
     this.authenticationServiceClient = new AuthenticationServiceClient(baseUri);
 
@@ -88,6 +94,11 @@ public abstract class AbstractMuleClient extends AbstractClient {
 
   public UserInfo getMe() {
     String userInfoJsonString = get(baseUri, ME, String.class);
+    if (userInfoJsonString.equalsIgnoreCase(UNAUTHORIZED)) {
+      StringBuilder message = new StringBuilder();
+      message.append("Unauthorized Access. Please verify that authToken is valid.");
+      throw new RuntimeException(message.toString());
+    }
     JsonObject userInfoJson = (JsonObject) new JsonParser().parse(userInfoJsonString);
     Organization organization = buildOrganization(userInfoJson);
     User user = new User();
@@ -128,8 +139,7 @@ public abstract class AbstractMuleClient extends AbstractClient {
   }
 
   /**
-   * Maps every organization id to a organization object
-   * Maps every organization id to its children organization ids
+   * Maps every organization id to a organization object Maps every organization id to its children organization ids
    *
    * @param userInfoJson
    * @param organizationsIds
@@ -284,9 +294,15 @@ public abstract class AbstractMuleClient extends AbstractClient {
     return currentOrgId;
   }
 
-  private String getBearerToken(Credentials credentials) {
+  private String getBearerToken(AnypointCredential credentials) {
     if (isBlank(bearerToken)) {
-      bearerToken = authenticationServiceClient.getBearerToken(credentials);
+      switch (credentials.credentialType()) {
+        case user:
+          Credentials creds = (Credentials) credentials;
+          bearerToken = authenticationServiceClient.getBearerToken(creds);
+        case token:
+          bearerToken = ((AnypointToken) credentials).getToken();
+      }
     }
 
     return bearerToken;

--- a/mule-deployer/src/main/java/org/mule/tools/client/authentication/model/AnypointCredential.java
+++ b/mule-deployer/src/main/java/org/mule/tools/client/authentication/model/AnypointCredential.java
@@ -1,0 +1,20 @@
+/*
+ * Mule ESB Maven Tools
+ * <p>
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * <p>
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.tools.client.authentication.model;
+
+/**
+ * @author Mulesoft Inc.
+ * @since 3.3.0
+ */
+public abstract class AnypointCredential {
+
+  public abstract CredentialType credentialType();
+
+}

--- a/mule-deployer/src/main/java/org/mule/tools/client/authentication/model/AnypointToken.java
+++ b/mule-deployer/src/main/java/org/mule/tools/client/authentication/model/AnypointToken.java
@@ -9,37 +9,28 @@
  */
 package org.mule.tools.client.authentication.model;
 
+import java.util.Objects;
 
 /**
  * @author Mulesoft Inc.
- * @since 2.0.0
+ * @since 3.3.0
  */
-public class Credentials extends AnypointCredential {
+public class AnypointToken extends AnypointCredential {
 
-  private final String username;
-  private final String password;
+  private final String bearerToken;
 
-  public Credentials(String username, String password) {
-    this.username = username;
-    this.password = password;
+  public AnypointToken(String bearerToken) {
+    Objects.requireNonNull(bearerToken, "Bearer token cannot be null");
+    this.bearerToken = bearerToken;
   }
 
-  public String getUsername() {
-    return username;
+  public String getToken() {
+    return this.bearerToken;
   }
 
-  public String getPassword() {
-    return password;
-  }
-
-  /**
-   * @since 3.3.0
-   */
   @Override
   public CredentialType credentialType() {
-    return CredentialType.user;
+    return CredentialType.token;
   }
-
-
 
 }

--- a/mule-deployer/src/main/java/org/mule/tools/client/authentication/model/CredentialType.java
+++ b/mule-deployer/src/main/java/org/mule/tools/client/authentication/model/CredentialType.java
@@ -1,0 +1,18 @@
+/*
+ * Mule ESB Maven Tools
+ * <p>
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * <p>
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.tools.client.authentication.model;
+
+/**
+ * @author Mulesoft Inc.
+ * @since 3.3.0
+ */
+public enum CredentialType {
+  user, token
+}

--- a/mule-deployer/src/main/java/org/mule/tools/model/anypoint/AnypointDeployment.java
+++ b/mule-deployer/src/main/java/org/mule/tools/model/anypoint/AnypointDeployment.java
@@ -33,6 +33,9 @@ public abstract class AnypointDeployment extends Deployment {
   protected String password;
 
   @Parameter
+  protected String authToken;
+
+  @Parameter
   protected String environment;
 
   @Parameter
@@ -75,6 +78,19 @@ public abstract class AnypointDeployment extends Deployment {
 
   public void setPassword(String password) {
     this.password = password;
+  }
+
+  /**
+   * Anypoint Platform Pre-authenticated bearer token.
+   *
+   * @since 3.3.0
+   */
+  public String getAuthToken() {
+    return this.authToken;
+  }
+
+  public void setAuthToken(String authToken) {
+    this.authToken = authToken;
   }
 
   /**
@@ -193,6 +209,11 @@ public abstract class AnypointDeployment extends Deployment {
     String username = getProperty("anypoint.username");
     if (isNotBlank(username)) {
       setUsername(username);
+    }
+
+    String authToken = getProperty("anypoint.authToken");
+    if (isNotBlank(authToken)) {
+      setAuthToken(authToken);
     }
   }
 }

--- a/mule-deployer/src/test/java/org/mule/tools/client/arm/ArmClientWithTokenTestCase.java
+++ b/mule-deployer/src/test/java/org/mule/tools/client/arm/ArmClientWithTokenTestCase.java
@@ -1,0 +1,79 @@
+/*
+ * Mule ESB Maven Tools
+ * <p>
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * <p>
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.tools.client.arm;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.concurrent.Callable;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.mule.tools.client.arm.model.Applications;
+import org.mule.tools.client.arm.model.Environment;
+import org.mule.tools.client.arm.model.Target;
+import org.mule.tools.model.anypoint.ArmDeployment;
+
+@Ignore
+public class ArmClientWithTokenTestCase {
+
+  private static final String AUTH_TOKEN = System.getProperty("anypoint.authToken");
+  
+  private static final String ENVIRONMENT = "Production";
+  private ArmClient armClient;
+  private ArmDeployment armDeployment;
+
+  @Before
+  public void setup() {
+    armDeployment = new ArmDeployment();
+    armDeployment.setUri("https://anypoint.mulesoft.com");
+    armDeployment.setAuthToken(AUTH_TOKEN);
+    armDeployment.setEnvironment(ENVIRONMENT);
+    armDeployment.setBusinessGroup("");
+    armDeployment.setArmInsecure(false);
+    armClient = new ArmClient(armDeployment, null);
+  }
+
+  @Test
+  public void getApplications() {
+    Applications apps = armClient.getApplications();
+    assertThat(apps, notNullValue());
+  }
+
+  @Test
+  public void findEnvironmentByName() {
+    Environment environment = armClient.findEnvironmentByName("Production");
+    assertThat(environment.name, equalTo("Production"));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void failToFindFakeEnvironment() {
+    armClient.findEnvironmentByName("notProduction");
+  }
+
+  @Test
+  public void findServerByName() {
+    Target target = armClient.findServerByName("server-name");
+    assertThat(target.name, equalTo("server-name"));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void failToFindFakeTargetName() {
+    armClient.findServerByName("fake-server-name");
+  }
+
+  private Callable<Boolean> appIsStarted(final int applicationId) {
+    return () -> armClient.isStarted(applicationId);
+  }
+
+}

--- a/mule-deployer/src/test/java/org/mule/tools/client/arm/ArmClientWithTokenTestCase.java
+++ b/mule-deployer/src/test/java/org/mule/tools/client/arm/ArmClientWithTokenTestCase.java
@@ -28,7 +28,7 @@ import org.mule.tools.model.anypoint.ArmDeployment;
 public class ArmClientWithTokenTestCase {
 
   private static final String AUTH_TOKEN = System.getProperty("anypoint.authToken");
-  
+
   private static final String ENVIRONMENT = "Production";
   private ArmClient armClient;
   private ArmDeployment armDeployment;


### PR DESCRIPTION
This PR adds a configuration to use Pre-Authenticated Bearer Token for authentication against the platform.

There is no change to authentication using username and password.

To use bearer token instead of username and password, either set a system property `anypoint.authToken` or add `<authToken>{token value}</authToken>` to the xml element, similar to username/password approach.

When bearer token is used, the plugin will use it as is for any operations against the anypoint platform apis. In case of invalid token, plugin throws unauthorized access error.
