### PR TITLE
Show correct error message corresponding to switch.

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/deployment/AbstractDeployerFactory.java
+++ b/mule-deployer/src/main/java/org/mule/tools/deployment/AbstractDeployerFactory.java
@@ -94,7 +94,7 @@ public abstract class AbstractDeployerFactory {
         case MULE_CLASSIFIER:
           return new ArmApplicationDeployer(deployment, log);
         default:
-          throw new RuntimeException("Deployment not supported: " + deployment.getClass().getSimpleName());
+          throw new RuntimeException("Packaging not supported: " + deployment.getPackaging());
       }
     }
   }
@@ -112,7 +112,7 @@ public abstract class AbstractDeployerFactory {
         case MULE_CLASSIFIER:
           return new AgentApplicationDeployer(deployment, log);
         default:
-          throw new RuntimeException("Deployment not supported: " + deployment.getClass().getSimpleName());
+          throw new RuntimeException("Packaging not supported: " + deployment.getPackaging());
       }
     }
   }
@@ -130,7 +130,7 @@ public abstract class AbstractDeployerFactory {
         case MULE_CLASSIFIER:
           return new StandaloneApplicationDeployer(deployment, log);
         default:
-          throw new RuntimeException("Deployment not supported: " + deployment.getClass().getSimpleName());
+          throw new RuntimeException("Packaging not supported: " + deployment.getPackaging());
       }
     }
   }
@@ -148,7 +148,7 @@ public abstract class AbstractDeployerFactory {
         case MULE_CLASSIFIER:
           return new CloudHubApplicationDeployer(deployment, log);
         default:
-          throw new RuntimeException("Deployment not supported: " + deployment.getClass().getSimpleName());
+          throw new RuntimeException("Packaging not supported: " + deployment.getPackaging());
       }
     }
   }
@@ -166,7 +166,7 @@ public abstract class AbstractDeployerFactory {
         case MULE_CLASSIFIER:
           return new RuntimeFabricApplicationDeployer(deployment, log);
         default:
-          throw new RuntimeException("Deployment not supported: " + deployment.getClass().getSimpleName());
+          throw new RuntimeException("Packaging not supported: " + deployment.getPackaging());
       }
     }
   }


### PR DESCRIPTION
Message thrown by AbstractDeployerFactory is confusing.
We got a "Deployment not supported: ArmDeployment" 
```15:17:16.318 [P=227711:O=0:CT] INFO  c.r.e.w.d.d.DeploybotRequest - [INFO] ------------------------------------------------------------------------
15:17:16.320 [P=227711:O=0:CT] INFO  c.r.e.w.d.d.DeploybotRequest - [ERROR] Failed to execute goal org.mule.tools.maven:mule-maven-plugin:2.3.3:undeploy (default-cli) on project mule-delete: Execution default-cli of goal org.mule.tools.maven:mule-maven-plugin:2.3.3:undeploy failed: Deployment not supported: ArmDeployment -> [Help 1]
15:17:16.320 [P=227711:O=0:CT] INFO  c.r.e.w.d.d.DeploybotRequest - [ERROR] 
```
but origin cause was the missing <packaging>mule</packaging> the the pom.xml.