### PR TITLE
fix redeployment status reporting

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/client/cloudhub/model/Application.java
+++ b/mule-deployer/src/main/java/org/mule/tools/client/cloudhub/model/Application.java
@@ -54,6 +54,8 @@ public class Application {
   // TODO a class VpnConfig
   private Map<String, String> vpnConfig;
 
+  private String deploymentUpdateStatus;
+
   public String getId() {
     return id;
   }
@@ -300,5 +302,13 @@ public class Application {
 
   public void setObjectStoreV1(Boolean objectStoreV1) {
     this.objectStoreV1 = objectStoreV1;
+  }
+
+  public String getDeploymentUpdateStatus() {
+    return deploymentUpdateStatus;
+  }
+
+  public void setDeploymentUpdateStatus(String deploymentUpdateStatus) {
+    this.deploymentUpdateStatus = deploymentUpdateStatus;
   }
 }

--- a/mule-deployer/src/main/java/org/mule/tools/verification/cloudhub/CloudHubDeploymentVerification.java
+++ b/mule-deployer/src/main/java/org/mule/tools/verification/cloudhub/CloudHubDeploymentVerification.java
@@ -9,56 +9,26 @@
  */
 package org.mule.tools.verification.cloudhub;
 
-import org.apache.commons.lang3.StringUtils;
-import org.mule.tools.client.cloudhub.model.Application;
 import org.mule.tools.client.cloudhub.CloudHubClient;
 import org.mule.tools.client.core.exception.DeploymentException;
 import org.mule.tools.model.Deployment;
 import org.mule.tools.verification.DefaultDeploymentVerification;
 import org.mule.tools.verification.DeploymentVerification;
-import org.mule.tools.verification.DeploymentVerificationStrategy;
-
-import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 public class CloudHubDeploymentVerification implements DeploymentVerification {
 
-  private final CloudHubClient client;
   private DefaultDeploymentVerification verification;
 
-  private static final String FAILED_STATUS = "FAIL";
-  public static final String STARTED_STATUS = "STARTED";
+  static final String FAILED_STATUS = "FAIL";
+  static final String STARTED_STATUS = "STARTED";
+  static final String DEPLOYMENT_IN_PROGRESS = "DEPLOYING";
 
   public CloudHubDeploymentVerification(CloudHubClient client) {
-    this.client = client;
-    this.verification = new DefaultDeploymentVerification(new CloudHubDeploymentVerificationStrategy());
+    this.verification = new DefaultDeploymentVerification(new CloudHubDeploymentVerificationStrategy(client));
   }
 
   @Override
   public void assertDeployment(Deployment deployment) throws DeploymentException {
     verification.assertDeployment(deployment);
-  }
-
-  private class CloudHubDeploymentVerificationStrategy implements DeploymentVerificationStrategy {
-
-    @Override
-    public Predicate<Deployment> isDeployed() {
-      return (deployment) -> {
-        Application application = client.getApplications(deployment.getApplicationName());
-        if (application != null) {
-          if (StringUtils.containsIgnoreCase(application.getStatus(), FAILED_STATUS)) {
-            throw new IllegalStateException("Deployment failed");
-          } else if (StringUtils.equals(STARTED_STATUS, application.getStatus())) {
-            return true;
-          }
-        }
-        return false;
-      };
-    }
-
-    @Override
-    public Consumer<Deployment> onTimeout() {
-      return deployment -> client.stopApplications(deployment.getApplicationName());
-    }
   }
 }

--- a/mule-deployer/src/main/java/org/mule/tools/verification/cloudhub/CloudHubDeploymentVerificationStrategy.java
+++ b/mule-deployer/src/main/java/org/mule/tools/verification/cloudhub/CloudHubDeploymentVerificationStrategy.java
@@ -1,0 +1,43 @@
+package org.mule.tools.verification.cloudhub;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mule.tools.client.cloudhub.CloudHubClient;
+import org.mule.tools.client.cloudhub.model.Application;
+import org.mule.tools.model.Deployment;
+import org.mule.tools.verification.DeploymentVerificationStrategy;
+
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static org.mule.tools.verification.cloudhub.CloudHubDeploymentVerification.DEPLOYMENT_IN_PROGRESS;
+import static org.mule.tools.verification.cloudhub.CloudHubDeploymentVerification.FAILED_STATUS;
+import static org.mule.tools.verification.cloudhub.CloudHubDeploymentVerification.STARTED_STATUS;
+
+public class CloudHubDeploymentVerificationStrategy implements DeploymentVerificationStrategy {
+    private final CloudHubClient client;
+
+    CloudHubDeploymentVerificationStrategy(CloudHubClient cloudHubClient) {
+        client = cloudHubClient;
+    }
+
+    @Override
+    public Predicate<Deployment> isDeployed() {
+        return (deployment) -> {
+            Application application = client.getApplications(deployment.getApplicationName());
+            if (application != null) {
+                if (StringUtils.containsIgnoreCase(application.getStatus(), FAILED_STATUS) || StringUtils.containsIgnoreCase(application.getDeploymentUpdateStatus(), FAILED_STATUS)) {
+                    throw new IllegalStateException("Deployment failed");
+                } else if (StringUtils.equals(application.getDeploymentUpdateStatus(), DEPLOYMENT_IN_PROGRESS)) {
+                    return false;
+                }
+                return StringUtils.equals(STARTED_STATUS, application.getStatus());
+            }
+            return false;
+        };
+    }
+
+    @Override
+    public Consumer<Deployment> onTimeout() {
+        return deployment -> client.stopApplications(deployment.getApplicationName());
+    }
+}

--- a/mule-deployer/src/main/java/org/mule/tools/verification/cloudhub/CloudHubDeploymentVerificationStrategy.java
+++ b/mule-deployer/src/main/java/org/mule/tools/verification/cloudhub/CloudHubDeploymentVerificationStrategy.java
@@ -1,3 +1,12 @@
+/*
+ * Mule ESB Maven Tools
+ * <p>
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * <p>
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
 package org.mule.tools.verification.cloudhub;
 
 import org.apache.commons.lang3.StringUtils;

--- a/mule-deployer/src/test/java/org/mule/tools/verification/cloudhub/CloudHubDeploymentVerificationStrategyTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/verification/cloudhub/CloudHubDeploymentVerificationStrategyTest.java
@@ -1,0 +1,62 @@
+/*
+ * Mule ESB Maven Tools
+ * <p>
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * <p>
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.tools.verification.cloudhub;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mule.tools.client.cloudhub.CloudHubClient;
+import org.mule.tools.client.cloudhub.model.Application;
+import org.mule.tools.model.Deployment;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static org.mule.tools.verification.cloudhub.CloudHubDeploymentVerification.DEPLOYMENT_IN_PROGRESS;
+import static org.mule.tools.verification.cloudhub.CloudHubDeploymentVerification.STARTED_STATUS;
+
+public class CloudHubDeploymentVerificationStrategyTest {
+    private final CloudHubClient cloudHubClient = mock(CloudHubClient.class);
+    private final CloudHubDeploymentVerificationStrategy cloudHubDeploymentVerificationStrategy = new CloudHubDeploymentVerificationStrategy(cloudHubClient);
+    private final Deployment deployment = new Deployment() {
+        @Override
+        public void setEnvironmentSpecificValues() {
+
+        }
+    };
+
+    @Before
+    public void testSetup() {
+        reset(cloudHubClient);
+    }
+
+    @Test
+    public void doesNotReportSuccessIfReDeploymentIsStillInProgress() {
+        Application startedApplicationWithDeploymentInProcess = new Application();
+        startedApplicationWithDeploymentInProcess.setStatus(STARTED_STATUS);
+        startedApplicationWithDeploymentInProcess.setDeploymentUpdateStatus(DEPLOYMENT_IN_PROGRESS);
+
+        when(cloudHubClient.getApplications(any())).thenReturn(startedApplicationWithDeploymentInProcess);
+
+        assertFalse(cloudHubDeploymentVerificationStrategy.isDeployed().test(deployment));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void reportFailureIfRedeploymentFailed() {
+        Application startedApplicationWithDeploymentFailed = new Application();
+        startedApplicationWithDeploymentFailed.setStatus(STARTED_STATUS);
+        startedApplicationWithDeploymentFailed.setDeploymentUpdateStatus("DEPLOY_FAILED");
+
+        when(cloudHubClient.getApplications(any())).thenReturn(startedApplicationWithDeploymentFailed);
+
+        cloudHubDeploymentVerificationStrategy.isDeployed().test(deployment);
+    }
+}


### PR DESCRIPTION
**Issue**: during redeployment of existing app that's already running plugin always reports success immediately.
**Cause**: unlike during initial app deployment the redeployment of existing app uses different property to indicate its status: app.status vs app.deploymentUpdateStatus.
**Fix**: check the `deploymentUpdateStatus` property also, returned by CludHub to identify redeployment state.