### PR TITLE
Set token extension header flag

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/client/AbstractMuleClient.java
+++ b/mule-deployer/src/main/java/org/mule/tools/client/AbstractMuleClient.java
@@ -12,6 +12,7 @@ package org.mule.tools.client;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.mule.tools.client.authentication.AuthenticationServiceClient.AUTHORIZATION_HEADER;
+import static org.mule.tools.client.authentication.AuthenticationServiceClient.ANYPOINT_SEESION_EXTEND;
 
 import java.util.*;
 
@@ -224,6 +225,7 @@ public abstract class AbstractMuleClient extends AbstractClient {
   protected void configureRequest(Invocation.Builder builder) {
     if (bearerToken != null) {
       builder.header(AUTHORIZATION_HEADER, "bearer " + bearerToken);
+      builder.header(ANYPOINT_SEESION_EXTEND, true);
     }
 
     if (envId != null && orgId != null) {

--- a/mule-deployer/src/main/java/org/mule/tools/client/authentication/AuthenticationServiceClient.java
+++ b/mule-deployer/src/main/java/org/mule/tools/client/authentication/AuthenticationServiceClient.java
@@ -40,6 +40,8 @@ public class AuthenticationServiceClient extends AbstractClient {
 
   public static final String AUTHORIZATION_HEADER = "Authorization";
 
+  public static final String ANYPOINT_SEESION_EXTEND = "x-anypoint-session-extend";
+
   public static final String LOGIN = "/accounts/login";
 
   public static final String BASE = "/accounts/api";

--- a/mule-deployer/src/test/java/org/mule/tools/client/AbstractMuleClientTestCase.java
+++ b/mule-deployer/src/test/java/org/mule/tools/client/AbstractMuleClientTestCase.java
@@ -10,15 +10,23 @@
 package org.mule.tools.client;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import javax.ws.rs.client.Invocation;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mule.tools.client.arm.ArmClient;
+import org.mule.tools.client.arm.model.Environment;
 import org.mule.tools.client.arm.model.Environments;
+import org.mule.tools.model.anypoint.ArmDeployment;
 import org.mule.tools.model.anypoint.CloudHubDeployment;
 
 
@@ -125,4 +133,20 @@ public class AbstractMuleClientTestCase {
     client.findEnvironmentByName("Production");
   }
 
+
+  @Test
+  public void configureRequestWithTokenExtension() {
+    ArmDeployment armDeployment = new ArmDeployment();
+    armDeployment.setUri(BASE_URI);
+    armDeployment.setAuthToken("dummyToken");
+    armDeployment.setEnvironment("dummyEnv");
+    armDeployment.setBusinessGroupId("dummyGroupId");
+    armDeployment.setArmInsecure(false);
+    AbstractMuleClient client = spy(new ArmClient(armDeployment, null));
+    Invocation.Builder builder = mock(Invocation.Builder.class);
+    doReturn(new Environment()).when(client).findEnvironmentByName("dummyEnv");
+    client.init();
+    client.configureRequest(builder);
+    verify(builder).header("x-anypoint-session-extend", true);
+  }
 }


### PR DESCRIPTION
This PR adds `x-anypoint-session-extend` header to base request builder. This will extend the user token expiration value.