### PR TITLE
Backported MMP-511 fixes to the 2.x branch.

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/verification/DefaultDeploymentVerification.java
+++ b/mule-deployer/src/main/java/org/mule/tools/verification/DefaultDeploymentVerification.java
@@ -40,7 +40,8 @@ public class DefaultDeploymentVerification implements DeploymentVerification {
       retrier.retry(verificationStrategy);
     } catch (InterruptedException | TimeoutException e) {
       verificationStrategy.onTimeout(deployment);
-      throw new DeploymentException("Deployment has timed out", e);
+      throw new DeploymentException("Validation timed out waiting for application to start. " +
+          "Please consider increasing the deploymentTimeout property.", e);
     }
   }
 }

--- a/mule-deployer/src/main/java/org/mule/tools/verification/fabric/RuntimeFabricDeploymentVerification.java
+++ b/mule-deployer/src/main/java/org/mule/tools/verification/fabric/RuntimeFabricDeploymentVerification.java
@@ -79,7 +79,7 @@ public class RuntimeFabricDeploymentVerification implements DeploymentVerificati
 
     @Override
     public void onTimeout(Deployment deployment) {
-      client.deleteDeployment(getDeploymentId(deployment));
+      return;
     }
 
     @Override

--- a/mule-deployer/src/test/java/org/mule/tools/verification/cloudhub/CloudHubDeploymentVerificationTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/verification/cloudhub/CloudHubDeploymentVerificationTest.java
@@ -56,7 +56,8 @@ public class CloudHubDeploymentVerificationTest {
   @Test
   public void assertReDeploymentStartedFalse() throws DeploymentException {
     expectedException.expect(DeploymentException.class);
-    expectedException.expectMessage("Deployment has timed out");
+    expectedException.expectMessage("Validation timed out waiting for application to start. " +
+        "Please consider increasing the deploymentTimeout property.");
     application.setStatus("STARTED");
     application.setDeploymentUpdateStatus("DEPLOYING");
     deployment.setDeploymentTimeout(1000L);
@@ -66,7 +67,8 @@ public class CloudHubDeploymentVerificationTest {
   @Test
   public void assertDeploymentStartedFalse() throws DeploymentException {
     expectedException.expect(DeploymentException.class);
-    expectedException.expectMessage("Deployment has timed out");
+    expectedException.expectMessage("Validation timed out waiting for application to start. " +
+        "Please consider increasing the deploymentTimeout property.");
     application.setStatus("DEPLOYING");
     deployment.setDeploymentTimeout(1000L);
     verification.assertDeployment(deployment);

--- a/mule-deployer/src/test/java/org/mule/tools/verification/fabric/RuntimeFabricDeploymentVerificationTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/verification/fabric/RuntimeFabricDeploymentVerificationTest.java
@@ -61,7 +61,8 @@ public class RuntimeFabricDeploymentVerificationTest {
   @Test
   public void assertDeploymentStartedFalse() throws DeploymentException {
     expectedException.expect(DeploymentException.class);
-    expectedException.expectMessage("Deployment has timed out");
+    expectedException.expectMessage("Validation timed out waiting for application to start. " +
+        "Please consider increasing the deploymentTimeout property.");
     deploymentDetailedResponse.status = "DEPLOYING";
     deployment.setDeploymentTimeout(1000L);
     verification.assertDeployment(deployment);


### PR DESCRIPTION
Original fix by julianpascualMuleSoft

MMP-511 Update error message when deploy validation fail with time out
MMP-511 Don't change app status on RTF deploy verification timeout (#329)

Co-authored-by: julianpascualMuleSoft <julian.pascual@mulesoft.com>