### PR TITLE
SE-17223:Maven Stops a Previous App Instance  if the Re-deployment Fails

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/verification/cloudhub/CloudHubDeploymentVerification.java
+++ b/mule-deployer/src/main/java/org/mule/tools/verification/cloudhub/CloudHubDeploymentVerification.java
@@ -63,7 +63,8 @@ public class CloudHubDeploymentVerification implements DeploymentVerification {
 
     @Override
     public Consumer<Deployment> onTimeout() {
-      return deployment -> client.stopApplications(deployment.getApplicationName());
+      return deployment -> {
+      };
     }
   }
 }


### PR DESCRIPTION
We don't have to stop the application if the deployment fails. If it is the first deploy we don't have to stop the app because it was never deployed. On the other hand, if we are doing a redeploy we should not stop it to respect the "zero downtime updates" policy (that is respected by ui and by cloudhub api): https://docs.mulesoft.com/runtime-manager/managing-applications-on-cloudhub#zero-downtime-updates-with-cloudhub