### PR TITLE
MMP-553:Review Exchange Plugin integration

### DIFF
--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/deploy/AbstractMuleDeployerMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/deploy/AbstractMuleDeployerMojo.java
@@ -108,10 +108,12 @@ public abstract class AbstractMuleDeployerMojo extends AbstractGenericMojo {
   }
 
   private void validateUniqueDeploymentConfiguration() throws ValidationException {
-    List<Deployment> deployments = getProjectInformation().getDeployments().stream()
-        .filter(Objects::nonNull).collect(Collectors.toList());
-
-    if (deployments.isEmpty()) {
+    List<Deployment> deployments = null;
+    if (getProjectInformation().getDeployments() != null) {
+      deployments = getProjectInformation().getDeployments().stream()
+          .filter(Objects::nonNull).collect(Collectors.toList());
+    }
+    if (deployments == null || deployments.isEmpty()) {
       throw new ValidationException("No deployment configuration was defined. Aborting.");
     }
     if (deployments.size() > 1) {


### PR DESCRIPTION
After the addition of the exchange plugin to MMP( https://github.com/mulesoft/mule-maven-plugin/commit/0479f13cf91c3f75bf133101e1975aa0457c17d9 ), the error message that
is shown when there is no configuration to do MuleDeploy is not the
same. Instead of showing "No deployment configuration was defined" it's
showing a NPE. This commit fix that.