### PR TITLE
SE-20120: MMP chooses 1st deployment of several with same name during RTF deployment 

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/deployment/fabric/RequestBuilder.java
+++ b/mule-deployer/src/main/java/org/mule/tools/deployment/fabric/RequestBuilder.java
@@ -139,7 +139,7 @@ public class RequestBuilder {
     return getTargetId(targets, targetName);
   }
 
-  private String getTargetId(JsonArray targets, String targetName) throws DeploymentException {
+  public static String getTargetId(JsonArray targets, String targetName) throws DeploymentException {
     for (JsonElement targetElement : targets) {
       JsonObject target = targetElement.getAsJsonObject();
       if (target != null) {
@@ -156,7 +156,7 @@ public class RequestBuilder {
         }
       }
     }
-    throw new DeploymentException("Could not find target " + deployment.getTarget());
+    throw new DeploymentException("Could not find target " + targetName);
   }
 
   private ApplicationRequest buildApplicationRequest() {

--- a/mule-deployer/src/test/java/org/mule/tools/verification/fabric/RuntimeFabricDeploymentVerificationTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/verification/fabric/RuntimeFabricDeploymentVerificationTest.java
@@ -18,8 +18,13 @@ import org.mule.tools.client.fabric.RuntimeFabricClient;
 import org.mule.tools.client.fabric.model.DeploymentDetailedResponse;
 import org.mule.tools.client.fabric.model.DeploymentGenericResponse;
 import org.mule.tools.client.fabric.model.Deployments;
-import org.mule.tools.model.Deployment;
+import org.mule.tools.client.fabric.model.Target;
 import org.mule.tools.model.anypoint.RuntimeFabricDeployment;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -31,7 +36,7 @@ public class RuntimeFabricDeploymentVerificationTest {
   private static final String APP_NAME = "app";
   private RuntimeFabricClient clientMock;
   private RuntimeFabricDeploymentVerification verification;
-  private Deployment deployment;
+  private RuntimeFabricDeployment deployment;
   private Deployments deployments;
   private DeploymentGenericResponse deploymentGenericResponse;
   private DeploymentDetailedResponse deploymentDetailedResponse;
@@ -45,9 +50,12 @@ public class RuntimeFabricDeploymentVerificationTest {
     deploymentDetailedResponse = new DeploymentDetailedResponse();
     deployment = new RuntimeFabricDeployment();
     deployment.setApplicationName(APP_NAME);
+    deployment.setTarget("rtf-local-4");
     deploymentGenericResponse = new DeploymentGenericResponse();
     deploymentGenericResponse.name = APP_NAME;
     deploymentGenericResponse.id = "1";
+    deploymentGenericResponse.target = new Target();
+    deploymentGenericResponse.target.setTargetId("8d7959fc-5405-43e9-9339-6df8d1c8c1d7");
     deployments = new Deployments();
     deployments.items = newArrayList(deploymentGenericResponse);
     verification = new RuntimeFabricDeploymentVerification(clientMock);
@@ -82,6 +90,19 @@ public class RuntimeFabricDeploymentVerificationTest {
     expectedException.expect(DeploymentException.class);
     expectedException.expectMessage("Deployment has failed");
     deploymentDetailedResponse.status = "FAILED";
+    verification.assertDeployment(deployment);
+  }
+
+  @Test
+  public void assertDeploymentWithTargetTrue() throws DeploymentException {
+    String content =
+        "{\"id\":\"8d7959fc-5405-43e9-9339-6df8d1c8c1d7\",\"region\":\"us-east-1\",\"agentInfo\":{\"name\":\"rtf-local-4\",\"organizationId\":\"96adae7f-fe4d-4cef-9bea-fa9004a47459\",\"status\":\"Active\",\"agentVersion\":\"1.8.50\",\"desiredAgentVersion\":\"1.8.50\",\"nodes\":[{\"uid\":\"a284920e-64d4-41e6-8a18-f237e5af2e54\",\"name\":\"kind-control-plane\",\"kubeletVersion\":\"v1.20.2\",\"dockerVersion\":\"containerd://1.4.0-106-gce4439a8\",\"role\":\"worker\",\"status\":{\"isHealthy\":true,\"isReady\":true,\"isSchedulable\":true},\"capacity\":{\"cpu\":8,\"cpuMillis\":8000,\"memory\":\"5948Mi\",\"memoryMi\":5948,\"pods\":110},\"allocatedRequestCapacity\":{\"cpu\":1,\"cpuMillis\":1250,\"memory\":\"690Mi\",\"memoryMi\":690,\"pods\":12},\"allocatedLimitCapacity\":{\"cpu\":2,\"cpuMillis\":2150,\"memory\":\"1740Mi\",\"memoryMi\":1740,\"pods\":12}}],\"secondsSinceHeartbeat\":0}}";
+    JsonParser jsonParser = new JsonParser();
+    JsonObject jsonObject = (JsonObject) jsonParser.parse(content);
+    JsonArray jsonArray = new JsonArray();
+    jsonArray.add(jsonObject);
+    when(clientMock.getTargets()).thenReturn(jsonArray);
+    deploymentDetailedResponse.status = "STARTED";
     verification.assertDeployment(deployment);
   }
 


### PR DESCRIPTION
We were not filtering by target when checking the deploy.

Previous behaviour:
When having two apps with the same name in two different RTFs, the verificator could verify the wrong one.

Current behaviour:
With the filter by target added to the verificator we ensure that the deployment that is being verified is taken from the right rtf.