### PR TITLE
MMP-566: Upgrade maven-compiler-plugin of Mule Lifecycle to 3.8.1

### DIFF
--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/MuleLifecycleMapping.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/MuleLifecycleMapping.java
@@ -50,7 +50,7 @@ public class MuleLifecycleMapping implements LifecycleMapping, ProjectLifecycleM
 
   private static final String MAVEN_RESOURCES_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-resources-plugin:3.0.2";
   private static final String MAVEN_CLEAN_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-clean-plugin:3.6.1";
-  private static final String MAVEN_COMPILER_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-compiler-plugin:3.8.0";
+  private static final String MAVEN_COMPILER_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-compiler-plugin:3.8.1";
   private static final String MAVEN_SUREFIRE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-surefire-plugin:2.19.1";
   private static final String MAVEN_INSTALL_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-install-plugin:2.5.2";
   private static final String MAVEN_DEPLOY_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-deploy-plugin:2.8.2";


### PR DESCRIPTION
This version (the latest at the time of writing this) was released on May 2019 and seems to be pretty stable after 2 years and no new releases.