### PR TITLE
MMP-567: Fix wrong maven-clean-plugin version for Mule Lifecycle

### DIFF
--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/MuleLifecycleMapping.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/MuleLifecycleMapping.java
@@ -49,7 +49,7 @@ public class MuleLifecycleMapping implements LifecycleMapping, ProjectLifecycleM
   private static final String EXCHANGE_PLUGIN = "org.mule.tools.maven";
 
   private static final String MAVEN_RESOURCES_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-resources-plugin:3.0.2";
-  private static final String MAVEN_CLEAN_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-clean-plugin:3.6.1";
+  private static final String MAVEN_CLEAN_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-clean-plugin:3.1.0";
   private static final String MAVEN_COMPILER_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-compiler-plugin:3.8.0";
   private static final String MAVEN_SUREFIRE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-surefire-plugin:2.19.1";
   private static final String MAVEN_INSTALL_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-install-plugin:2.5.2";


### PR DESCRIPTION
The previous version (3.6.1) does not currently exists. At the time of writing this the latest version is 3.1.0 on Maven Central.