### PR TITLE
Set maven-jar-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,6 +467,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifest>


### PR DESCRIPTION
Setting the version prevents showing several warnings like the following one at the start of the building and makes it more stable and predictable.

```
$ mvn clean package
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.mule.tools.maven:mule-packager:jar:3.5.2-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ org.mule.tools.maven:mule-artifact-tools:3.5.2-SNAPSHOT, /Users/mdaloia/dev/projects/mule-maven-plugin/pom.xml, line 467, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.mule.tools.maven:mule-classloader-model:jar:3.5.2-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ org.mule.tools.maven:mule-artifact-tools:3.5.2-SNAPSHOT, /Users/mdaloia/dev/projects/mule-maven-plugin/pom.xml, line 467, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.mule.tools.maven:mule-deployer:jar:3.5.2-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ org.mule.tools.maven:mule-artifact-tools:3.5.2-SNAPSHOT, /Users/mdaloia/dev/projects/mule-maven-plugin/pom.xml, line 467, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.mule.tools.maven:mule-maven-plugin:maven-plugin:3.5.2-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ org.mule.tools.maven:mule-artifact-tools:3.5.2-SNAPSHOT, /Users/mdaloia/dev/projects/mule-maven-plugin/pom.xml, line 467, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.mule.tools.maven:mule-packager-it:jar:3.5.2-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ org.mule.tools.maven:mule-artifact-tools:3.5.2-SNAPSHOT, /Users/mdaloia/dev/projects/mule-maven-plugin/pom.xml, line 467, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.mule.tools.maven:mule-artifact-it:pom:3.5.2-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ org.mule.tools.maven:mule-artifact-tools:3.5.2-SNAPSHOT, /Users/mdaloia/dev/projects/mule-maven-plugin/pom.xml, line 467, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.mule.tools.maven:mule-artifact-tools:pom:3.5.2-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 467, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```