### PR TITLE
SE-20302:CloudHub Deployment Fails with Error 400 Bad Request

### DIFF
--- a/mule-artifact-it/mule-deployer-it/src/test/java/integration/test/mojo/CloudHubDeploymentTest.java
+++ b/mule-artifact-it/mule-deployer-it/src/test/java/integration/test/mojo/CloudHubDeploymentTest.java
@@ -88,7 +88,7 @@ public class CloudHubDeploymentTest extends AbstractDeploymentTest {
 
   @Parameterized.Parameters
   public static Iterable<? extends Object> data() {
-    return Arrays.asList("4.0.0", "4.1.0", "4.2.2");
+    return Arrays.asList("4.3.0-SNAPSHOT");
   }
 
   private String muleVersion;
@@ -117,7 +117,7 @@ public class CloudHubDeploymentTest extends AbstractDeploymentTest {
 
   @Test
   public void testCloudHubDeploy() throws VerificationException, InterruptedException, TimeoutException, DeploymentException {
-    String version = muleVersion;
+    String version = muleVersion.replace(SNAPSHOT_SUFFIX, "");;
 
     assumeTrue("Version not supported by CloudHub", cloudHubClient.getSupportedMuleVersions().stream().map(sv -> sv.getVersion())
         .collect(Collectors.toSet()).contains(version));

--- a/mule-artifact-it/mule-deployer-it/src/test/java/integration/test/mojo/CloudHubDeploymentTest.java
+++ b/mule-artifact-it/mule-deployer-it/src/test/java/integration/test/mojo/CloudHubDeploymentTest.java
@@ -117,7 +117,7 @@ public class CloudHubDeploymentTest extends AbstractDeploymentTest {
 
   @Test
   public void testCloudHubDeploy() throws VerificationException, InterruptedException, TimeoutException, DeploymentException {
-    String version = muleVersion.replace(SNAPSHOT_SUFFIX, "");
+    String version = muleVersion;
 
     assumeTrue("Version not supported by CloudHub", cloudHubClient.getSupportedMuleVersions().stream().map(sv -> sv.getVersion())
         .collect(Collectors.toSet()).contains(version));

--- a/mule-artifact-it/mule-deployer-it/src/test/resources/empty-mule-deploy-cloudhub-project/mule-artifact.json
+++ b/mule-artifact-it/mule-deployer-it/src/test/resources/empty-mule-deploy-cloudhub-project/mule-artifact.json
@@ -1,6 +1,6 @@
 {
   "name": "new-package",
-  "minMuleVersion": "4.0.0-SNAPSHOT",
+  "minMuleVersion": "4.3.0-SNAPSHOT",
   "classLoaderModelLoaderDescriptor": {
     "id": "mule",
     "attributes": {

--- a/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
+++ b/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
@@ -151,7 +151,7 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
    * Updates the application in CloudHub.
    *
    * @throws DeploymentException In case the application is not available for the current user or some other internal in CloudHub
-   *                             happens
+   *         happens
    */
   protected void updateApplication() throws DeploymentException {
     Application currentApplication = client.getApplications(deployment.getApplicationName());
@@ -189,9 +189,9 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
     Integer workersAmount;
     String workerType;
     MuleVersion muleVersion = new MuleVersion();
-    muleVersion.setVersion(deployment.getMuleVersion().get());
 
     if (originalApplication != null) {
+      muleVersion.setVersion(deployment.getMuleVersion().get());
       Map<String, String> resolvedProperties = resolveProperties(originalApplication.getProperties(),
                                                                  deployment.getProperties(), deployment.overrideProperties());
       application.setProperties(resolvedProperties);
@@ -212,6 +212,7 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
           isBlank(deployment.getWorkerType()) ? originalApplication.getWorkers().getType().getName() : deployment.getWorkerType();
 
     } else {
+      muleVersion.setVersion(deployment.getMuleVersion().get().split("-")[0]);
       application.setMonitoringAutoRestart(true);
       application.setProperties(deployment.getProperties());
 


### PR DESCRIPTION
Removing suffix for deployments because Ch always uses the last patch
for the version (if a suffix is specified it fails). For redeploys we do
nothing because you can deploy to the patch that is already running. I am updating the versions to the ones available in the cloudhub testing account currently and adding a SNAPSHOT suffix to test this fix.