### PR TITLE
add support/3.5.x to protected branches

### DIFF
--- a/build.jenkinsfile
+++ b/build.jenkinsfile
@@ -13,7 +13,7 @@ def pipelineParams = [
   "jdk": params.JDK,
   "maven": params.maven,
   "projectKey": "mule-maven-plugin",
-  "protectedBranches" : ["support/3.x", "support/3.4.x", "support/3.3.x", "support/2.x"]
+  "protectedBranches" : ["support/3.x", "support/3.5.x", "support/3.4.x", "support/3.3.x", "support/2.x"]
 ]
 
 build(pipelineParams)


### PR DESCRIPTION
 in order to deploy 3.5.3-SNAPSHOT to the internal repo