### PR TITLE
SE-21008:Maven Plugin: Failing to build application from command line

### DIFF
--- a/mule-packager/src/main/java/org/mule/tools/api/repository/ArtifactInstaller.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/repository/ArtifactInstaller.java
@@ -98,7 +98,9 @@ public class ArtifactInstaller {
     if (!srcPomFile.exists()) {
       srcPomFile = new File(srcPomFolder, POM_FILE_NAME);
     }
-    copyFile(srcPomFile, destinationPomFile);
+    if (srcPomFile.exists()) {
+      copyFile(srcPomFile, destinationPomFile);
+    }
   }
 
   @Deprecated

--- a/mule-packager/src/test/java/org/mule/tools/api/repository/ArtifactInstallerTest.java
+++ b/mule-packager/src/test/java/org/mule/tools/api/repository/ArtifactInstallerTest.java
@@ -119,5 +119,14 @@ public class ArtifactInstallerTest {
 
     assertThat("Pom file should have been created", generatedPomFile.exists(), is(true));
   }
+  
+  @Test
+  public void generatePomFileWhenPomFileDoesNotExistTest() throws IOException {
+    File generatedPomFile = new File(outputFolder.getRoot(), POM_FILE_NAME);
+
+    assertThat("Pom file should not exist", generatedPomFile.exists(), is(false));
+
+    installer.generatePomFile(artifact, outputFolder.getRoot());
+  }
 
 }


### PR DESCRIPTION
The artifact installer is assuming that every dependency has a pom file.
This is not the case for the tools.jar that is obtained from the jre.
This fix consists of checking that the pom exists before trying to copy
it to target folder.