### PR TITLE
MMP-586: Package EE dependencies when building MMP

### DIFF
--- a/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/InstallMojoTest.java
+++ b/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/InstallMojoTest.java
@@ -152,6 +152,7 @@ public class InstallMojoTest extends MojoTest {
     projectBaseDirectory = builder.createProjectBaseDir(artifactId, this.getClass());
     verifier = buildVerifier(projectBaseDirectory);
     verifier.addCliOption("-DattachMuleSources=true");
+    verifier.addCliOption("-DskipAST");
 
     verifier.deleteArtifacts(GROUP_ID, appSubModule, VERSION);
     String artifactPath = verifier.getArtifactPath(GROUP_ID, appSubModule, VERSION, EXT, MULE_APPLICATION_CLASSIFIER);

--- a/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/InstallMojoTest.java
+++ b/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/InstallMojoTest.java
@@ -152,7 +152,6 @@ public class InstallMojoTest extends MojoTest {
     projectBaseDirectory = builder.createProjectBaseDir(artifactId, this.getClass());
     verifier = buildVerifier(projectBaseDirectory);
     verifier.addCliOption("-DattachMuleSources=true");
-    verifier.addCliOption("-DskipAST");
 
     verifier.deleteArtifacts(GROUP_ID, appSubModule, VERSION);
     String artifactPath = verifier.getArtifactPath(GROUP_ID, appSubModule, VERSION, EXT, MULE_APPLICATION_CLASSIFIER);

--- a/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/MojoTest.java
+++ b/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/MojoTest.java
@@ -13,6 +13,7 @@ import static integration.ProjectFactory.createProjectBaseDir;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.apache.commons.io.FileUtils.deleteDirectory;
 import org.mule.tools.api.util.FileUtils;
+import org.mule.tools.maven.mojo.CompileMojo;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,7 +29,8 @@ import org.junit.Before;
 
 public class MojoTest implements SettingsConfigurator {
 
-  protected static final String[] excludes = new String[] {".placeholder", "log.txt"};
+  protected static final String[] excludes =
+      new String[] {".placeholder", "log.txt", CompileMojo.EXT_MODEL_LOADER_DEPENDENCIES_TARGET};
   protected static final String[] excludesCompile = ArrayUtils.addAll(excludes, "maven-status");
 
   protected static final String TARGET_FOLDER_NAME = "target";

--- a/mule-extension-model-loader/pom.xml
+++ b/mule-extension-model-loader/pom.xml
@@ -12,8 +12,10 @@
     <name>Mule Extension Model Loader</name>
 
     <properties>
+        <licensePath>../LICENSE_HEADER.txt</licensePath>
+        <formatterConfigPath>../formatter.xml</formatterConfigPath>
         <coverageLineLimit>0.62</coverageLineLimit>
-        <coverageBranchLimit>0.40</coverageBranchLimit>
+        <coverageBranchLimit>0.41</coverageBranchLimit>
     </properties>
  <build>
 

--- a/mule-extension-model-loader/pom.xml
+++ b/mule-extension-model-loader/pom.xml
@@ -8,17 +8,61 @@
         <version>3.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-
     <artifactId>mule-extension-model-loader</artifactId>
     <name>Mule Extension Model Loader</name>
 
     <properties>
-        <licensePath>../LICENSE_HEADER.txt</licensePath>
-        <formatterConfigPath>../formatter.xml</formatterConfigPath>
+        <coverageLineLimit>0.62</coverageLineLimit>
+        <coverageBranchLimit>0.40</coverageBranchLimit>
     </properties>
+ <build>
 
+<plugins>
+	<plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/alternateLocation</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>false</overWriteSnapshots>
+              <overWriteIfNewer>true</overWriteIfNewer>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+            <classesDirectory>${project.build.directory}</classesDirectory>
+              <classifier>dependencies</classifier>
+          <includes>
+            <include>/alternateLocation/</include>
+          </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+</plugins>   
+
+
+ 
+ </build>
     <dependencies>
-
         <dependency>
             <groupId> org.mule.runtime</groupId>
             <artifactId>mule-module-logging</artifactId>

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
@@ -73,7 +73,7 @@ public class CompileMojo extends AbstractMuleMojo {
     } catch (IllegalArgumentException | IOException e) {
       throw new MojoFailureException("Fail to compile", e);
     }
- }
+  }
 
   private void addJarsToClasspath() throws ZipException, IOException {
     Path targetDirPath = getProjectInformation().getBuildDirectory().resolve(EXT_MODEL_LOADER_DEPENDENCIES_TARGET);

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
@@ -54,7 +54,7 @@ public class CompileMojo extends AbstractMuleMojo {
   private static final String MULE_POLICY = "mule-policy";
   private static final String MULE_DOMAIN = "mule-domain";
   private static final String SKIP_AST = "skipAST";
-  private static final String EXT_MODEL_LOADER_DEPENDENCIES_TARGET = "jars";
+  public static final String EXT_MODEL_LOADER_DEPENDENCIES_TARGET = "jars";
   private static final String EXT_MODEL_LOADER_DEPENDENCIES_FOLDER = "alternateLocation";
 
   @Override
@@ -69,30 +69,11 @@ public class CompileMojo extends AbstractMuleMojo {
         if (artifact != null) {
           ((MuleContentGenerator) getContentGenerator()).createAstFile(serialize(artifact));
         }
-        deleteDepsFolder();
       }
     } catch (IllegalArgumentException | IOException e) {
       throw new MojoFailureException("Fail to compile", e);
     }
-  }
-
-  private void deleteDepsFolder() throws IOException {
-    if ((getProjectInformation() != null) && (getProjectInformation().getBuildDirectory() != null)
-        && (getProjectInformation().getBuildDirectory().resolve(EXT_MODEL_LOADER_DEPENDENCIES_TARGET).toFile().exists())) {
-      Path dependenciesDir = getProjectInformation().getBuildDirectory().resolve(EXT_MODEL_LOADER_DEPENDENCIES_TARGET);
-      Files.walk(dependenciesDir.resolve(EXT_MODEL_LOADER_DEPENDENCIES_FOLDER))
-          .map(Path::toFile)
-          .forEach(File::delete);
-      dependenciesDir.resolve(EXT_MODEL_LOADER_DEPENDENCIES_FOLDER).toFile().delete();
-
-      Files.walk(dependenciesDir.resolve("META-INF"))
-          .sorted(Comparator.reverseOrder())
-          .map(Path::toFile)
-          .forEach(File::delete);
-      dependenciesDir.toFile().delete();
-    }
-
-  }
+ }
 
   private void addJarsToClasspath() throws ZipException, IOException {
     Path targetDirPath = getProjectInformation().getBuildDirectory().resolve(EXT_MODEL_LOADER_DEPENDENCIES_TARGET);
@@ -100,12 +81,8 @@ public class CompileMojo extends AbstractMuleMojo {
     File dependenciesDir = targetDirPath.resolve(EXT_MODEL_LOADER_DEPENDENCIES_FOLDER).toFile();
     extractDependencies(targetDirPath);
     File[] jarDeps = dependenciesDir.listFiles(file -> file.getAbsolutePath().endsWith("jar"));
-    URL[] urls = new URL[jarDeps.length];
-    int i = 0;
     for (File file : jarDeps) {
-      urls[i] = (file.toURI().toURL());
       descriptor.getClassRealm().addURL(file.toURI().toURL());
-      i++;
     }
   }
 

--- a/mule-packager/pom.xml
+++ b/mule-packager/pom.xml
@@ -32,7 +32,7 @@
     </build>
 
     <dependencies>
-        <dependency>
+         <dependency>
             <groupId>org.mule.tools.maven</groupId>
             <artifactId>mule-classloader-model</artifactId>
             <version>${project.version}</version>
@@ -46,6 +46,58 @@
             <groupId>org.mule.tools.maven</groupId>
             <artifactId>mule-extension-model-loader</artifactId>
             <version>${project.version}</version>
+            <classifier>dependencies</classifier>
+            <exclusions>
+        		<exclusion>
+            		<groupId>*</groupId>
+            		<artifactId>*</artifactId>
+        		</exclusion>
+        	</exclusions>
+        </dependency>
+		<dependency>
+            <groupId>org.mule.tools.maven</groupId>
+            <artifactId>mule-extension-model-loader</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+        		<exclusion>
+            		<groupId>com.mulesoft.anypoint</groupId>
+            		<artifactId>api-gateway-api</artifactId>
+        		</exclusion>
+        		<exclusion>
+            		<groupId>com.mulesoft.mule.runtime</groupId>
+           			<artifactId>mule-core-ee</artifactId>
+        		</exclusion>
+        		<exclusion>
+        			<groupId>org.mule.runtime</groupId>
+            		<artifactId>mule-api</artifactId>
+        		</exclusion>
+        		<exclusion>
+            		<groupId>org.mule</groupId>
+            		<artifactId>mule-maven-client-impl</artifactId>   		
+        		</exclusion>
+        		<exclusion>
+            		<groupId> org.mule.runtime</groupId>
+            		<artifactId>mule-module-logging</artifactId>        		
+        		</exclusion>
+        		<exclusion>
+                	<groupId>com.mulesoft.anypoint</groupId>
+                	<artifactId>mule-module-autodiscovery</artifactId>
+        		</exclusion>
+        		<exclusion>
+            		<groupId>com.mulesoft.mule.runtime.modules</groupId>
+            		<artifactId>mule-runtime-ee-extension-model</artifactId>
+        		</exclusion> 
+
+        		<exclusion>
+        			<groupId>org.mule.runtime</groupId>
+            		<artifactId>mule-module-javaee</artifactId>
+        		</exclusion>
+        		 <exclusion>
+        			<groupId>org.mule.runtime</groupId>
+            		<artifactId>mule-module-deployment-model-impl</artifactId>
+        		</exclusion>
+
+        </exclusions> 
         </dependency>
         
         <dependency>
@@ -126,6 +178,7 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
     </organization>
 
     <modules>
-    	<module>mule-extension-model-loader</module>
         <module>mule-packager</module>
         <module>mule-classloader-model</module>
         <module>mule-deployer</module>
@@ -46,7 +45,7 @@
         <java.target>1.8</java.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <mule.version>4.5.0-SNAPSHOT</mule.version>
+        <mule.version>4.5.0-20211019</mule.version>
         <mule.api.version>1.5.0-SNAPSHOT</mule.api.version>
         <mule.maven.client.impl.version>1.6.1-SNAPSHOT</mule.maven.client.impl.version>
         <mule.distribution.standalone.version>4.4.0</mule.distribution.standalone.version>


### PR DESCRIPTION
We need EE dependencies to obtain the ext-models of the mule plugins for
the AST. But the MMP should not need the EE repos configured to be used.
So, these new dependencies are packaged in a
mule-extension-model-loader-dependencies.jar. When mmp is used this jar
is uncompressed and the inner jars are added to the classpath