### PR TITLE
[SE-23105] - Mule Maven Plugin not finding Transitive Dependencies for Shared Libraries

### DIFF
--- a/mule-packager/src/main/java/org/mule/tools/api/util/ArtifactUtils.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/util/ArtifactUtils.java
@@ -76,6 +76,17 @@ public class ArtifactUtils {
   }
 
   /**
+   * Converts a {@link org.apache.maven.artifact.Artifact} instance to a {@link ArtifactCoordinates} instance.
+   *
+   * @param artifact the dependency to be converted.
+   * @return the corresponding {@link ArtifactCoordinates} instance.
+   */
+  public static ArtifactCoordinates toArtifactCoordinates(org.apache.maven.artifact.Artifact artifact) {
+    return new ArtifactCoordinates(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(),
+                                   artifact.getType(), artifact.getClassifier(), artifact.getScope());
+  }
+
+  /**
    * Converts a {@link ArtifactCoordinates} instance to a {@link org.mule.maven.client.api.model.BundleDescriptor} instance.
    *
    * @param artifactCoordinates the artifact coordinates to be converted.

--- a/mule-packager/src/main/java/org/mule/tools/api/util/DependencyProject.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/util/DependencyProject.java
@@ -16,14 +16,13 @@ import org.mule.maven.client.api.model.BundleDependency;
 import org.mule.maven.client.api.model.BundleDescriptor;
 import org.mule.maven.client.api.model.BundleScope;
 import org.mule.tools.api.classloader.model.ArtifactCoordinates;
-import org.mule.tools.api.util.Project;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class DependencyProject implements Project {
 
-  private MavenProject mavenProject;
+  private final MavenProject mavenProject;
 
   public DependencyProject(MavenProject mavenProject) {
     this.mavenProject = mavenProject;
@@ -31,7 +30,7 @@ public class DependencyProject implements Project {
 
   @Override
   public List<ArtifactCoordinates> getDependencies() {
-    return mavenProject.getDependencies().stream().map(ArtifactUtils::toArtifactCoordinates).collect(Collectors.toList());
+    return mavenProject.getArtifacts().stream().map(ArtifactUtils::toArtifactCoordinates).collect(Collectors.toList());
   }
 
   @Override


### PR DESCRIPTION
Using getArtifacts instead of getDependencies because returns all dependencies including the transitive ones.

https://maven.apache.org/ref/3.2.3/apidocs/org/apache/maven/project/MavenProject.html#getArtifacts()