### PR TITLE
[SE-23105][W-10624135] - Mule Maven Plugin not finding Transitive Dependencies for Shared Libraries

### DIFF
--- a/mule-packager/src/main/java/org/mule/tools/api/util/ArtifactUtils.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/util/ArtifactUtils.java
@@ -76,6 +76,17 @@ public class ArtifactUtils {
   }
 
   /**
+   * Converts a {@link org.apache.maven.artifact.Artifact} instance to a {@link ArtifactCoordinates} instance.
+   *
+   * @param artifact the dependency to be converted.
+   * @return the corresponding {@link ArtifactCoordinates} instance.
+   */
+  public static ArtifactCoordinates toArtifactCoordinates(org.apache.maven.artifact.Artifact artifact) {
+    return new ArtifactCoordinates(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(),
+                                   artifact.getType(), artifact.getClassifier(), artifact.getScope());
+  }
+
+  /**
    * Converts a {@link ArtifactCoordinates} instance to a {@link org.mule.maven.client.api.model.BundleDescriptor} instance.
    *
    * @param artifactCoordinates the artifact coordinates to be converted.

--- a/mule-packager/src/main/java/org/mule/tools/api/util/DependencyProject.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/util/DependencyProject.java
@@ -16,22 +16,26 @@ import org.mule.maven.client.api.model.BundleDependency;
 import org.mule.maven.client.api.model.BundleDescriptor;
 import org.mule.maven.client.api.model.BundleScope;
 import org.mule.tools.api.classloader.model.ArtifactCoordinates;
-import org.mule.tools.api.util.Project;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class DependencyProject implements Project {
 
-  private MavenProject mavenProject;
+  private final MavenProject mavenProject;
 
   public DependencyProject(MavenProject mavenProject) {
     this.mavenProject = mavenProject;
   }
 
   @Override
-  public List<ArtifactCoordinates> getDependencies() {
+  public List<ArtifactCoordinates> getDirectDependencies() {
     return mavenProject.getDependencies().stream().map(ArtifactUtils::toArtifactCoordinates).collect(Collectors.toList());
+  }
+
+  @Override
+  public List<ArtifactCoordinates> getDependencies() {
+    return mavenProject.getArtifacts().stream().map(ArtifactUtils::toArtifactCoordinates).collect(Collectors.toList());
   }
 
   @Override

--- a/mule-packager/src/main/java/org/mule/tools/api/util/Project.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/util/Project.java
@@ -17,7 +17,11 @@ import java.util.List;
 
 public interface Project {
 
-  List<ArtifactCoordinates> getDependencies();
+  List<ArtifactCoordinates> getDirectDependencies();
+
+  default List<ArtifactCoordinates> getDependencies() {
+    return getDirectDependencies();
+  }
 
   List<BundleDependency> getBundleDependencies();
 }

--- a/mule-packager/src/main/java/org/mule/tools/api/util/SourcesProcessor.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/util/SourcesProcessor.java
@@ -165,7 +165,7 @@ public class SourcesProcessor {
     return new Project() {
 
       @Override
-      public List<ArtifactCoordinates> getDependencies() {
+      public List<ArtifactCoordinates> getDirectDependencies() {
         return classLoaderModel.getDependencies()
             .stream()
             .map(Artifact::getArtifactCoordinates)

--- a/mule-packager/src/main/java/org/mule/tools/api/validation/project/DomainBundleProjectValidator.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/validation/project/DomainBundleProjectValidator.java
@@ -50,13 +50,13 @@ public class DomainBundleProjectValidator extends AbstractProjectValidator {
   @Override
   protected void additionalValidation() throws ValidationException {
     Set<ArtifactCoordinates> domains =
-        projectInformation.getProject().getDependencies().stream().filter(d -> MULE_DOMAIN.equals(d.getClassifier()))
+        projectInformation.getProject().getDirectDependencies().stream().filter(d -> MULE_DOMAIN.equals(d.getClassifier()))
             .collect(Collectors.toSet());
 
     validateDomain(domains);
 
     List<ArtifactCoordinates> applications =
-        projectInformation.getProject().getDependencies().stream().filter(d -> !MULE_DOMAIN.equals(d.getClassifier()))
+        projectInformation.getProject().getDirectDependencies().stream().filter(d -> !MULE_DOMAIN.equals(d.getClassifier()))
             .collect(Collectors.toList());
 
     validateApplications(domains.iterator().next(), applications);

--- a/mule-packager/src/main/java/org/mule/tools/api/validation/project/MuleProjectValidator.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/validation/project/MuleProjectValidator.java
@@ -27,7 +27,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.mule.tools.api.classloader.model.ArtifactCoordinates;
 import org.mule.tools.api.classloader.model.SharedLibraryDependency;
 import org.mule.tools.api.exception.ValidationException;
-import org.mule.tools.api.packager.DefaultProjectInformation;
 import org.mule.tools.api.packager.ProjectInformation;
 import org.mule.tools.api.packager.packaging.PackagingType;
 import org.mule.tools.api.validation.MuleArtifactJsonValidator;
@@ -76,7 +75,7 @@ public class MuleProjectValidator extends AbstractProjectValidator {
     isProjectStructureValid(projectInformation.getPackaging(), projectInformation.getProjectBaseFolder());
     //    validateDescriptorFile(projectInformation.getProjectBaseFolder(), deployMuleVersion);
     validateSharedLibraries(sharedLibraries, projectInformation.getProject().getDependencies());
-    validateReferencedDomainsIfPresent(projectInformation.getProject().getDependencies());
+    validateReferencedDomainsIfPresent(projectInformation.getProject().getDirectDependencies());
   }
 
   @Override

--- a/mule-packager/src/main/java/org/mule/tools/api/validation/resolver/model/DependenciesFilter.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/validation/resolver/model/DependenciesFilter.java
@@ -38,7 +38,7 @@ public class DependenciesFilter {
    * @return The filtered list of artifacts
    */
   public Set<ArtifactCoordinates> filter(ProjectDependencyNode node) {
-    return node.getProject().getDependencies().stream()
+    return node.getProject().getDirectDependencies().stream()
         .filter(satisfies(classifier, scope, DEFAULT_TYPE))
         .collect(Collectors.toSet());
   }

--- a/mule-packager/src/test/java/org/mule/tools/api/validation/project/DomainBundleProjectValidatorTest.java
+++ b/mule-packager/src/test/java/org/mule/tools/api/validation/project/DomainBundleProjectValidatorTest.java
@@ -18,7 +18,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.mule.maven.client.api.model.BundleDependency;
 import org.mule.maven.client.api.model.BundleDescriptor;
-import org.mule.maven.client.api.model.BundleScope;
 import org.mule.maven.client.internal.AetherMavenClient;
 import org.mule.tools.api.classloader.model.ArtifactCoordinates;
 import org.mule.tools.api.classloader.model.util.ArtifactUtils;
@@ -26,7 +25,6 @@ import org.mule.tools.api.exception.ValidationException;
 import org.mule.tools.api.packager.Pom;
 import org.mule.tools.api.packager.DefaultProjectInformation;
 import org.mule.tools.api.util.Project;
-import org.mule.tools.api.validation.resolver.MulePluginResolver;
 
 import java.io.File;
 import java.io.IOException;
@@ -306,7 +304,7 @@ public class DomainBundleProjectValidatorTest {
 
     List<ArtifactCoordinates> applicationDependencies = buildApplicationDependenciesWithDomain(applicationDomain);
 
-    when(dependencyProjectMock.getDependencies()).thenReturn(applicationDependencies);
+    when(dependencyProjectMock.getDirectDependencies()).thenReturn(applicationDependencies);
 
     DomainBundleProjectValidator validatorSpy =
         spy(new DomainBundleProjectValidator(defaultProjectInformation, aetherMavenClientMock));

--- a/mule-packager/src/test/java/org/mule/tools/api/validation/resolver/MulePluginResolverTest.java
+++ b/mule-packager/src/test/java/org/mule/tools/api/validation/resolver/MulePluginResolverTest.java
@@ -49,7 +49,7 @@ public class MulePluginResolverTest {
     dependency = createDependencyWithClassifierAndScope(MULE_PLUGIN_CLASSIFIER, COMPILE_SCOPE);
     Map<ArtifactCoordinates, List<ArtifactCoordinates>> projectStructure = createMainResolvableProjectDependencyTree(dependency);
     setUpProjectBuilderMock(projectStructure, projectBuilderMock);
-    when(projectMock.getDependencies()).thenReturn(projectStructure.entrySet().stream().filter(entry -> {
+    when(projectMock.getDirectDependencies()).thenReturn(projectStructure.entrySet().stream().filter(entry -> {
       ArtifactCoordinates coordinates = entry.getKey();
       return coordinates.getGroupId().equals(dependency.getGroupId()) && coordinates.getArtifactId()
           .equals(dependency.getArtifactId());

--- a/mule-packager/src/test/java/org/mule/tools/api/validation/resolver/model/DependenciesFilterTest.java
+++ b/mule-packager/src/test/java/org/mule/tools/api/validation/resolver/model/DependenciesFilterTest.java
@@ -42,7 +42,7 @@ public class DependenciesFilterTest {
     projectMock = mock(Project.class);
     nodeMock = new ProjectDependencyNode(projectMock, mock(ProjectBuilder.class));
     projectMockDependencies = newArrayList(artifactCoordinates_a, artifactCoordinates_b);
-    when(projectMock.getDependencies()).thenReturn(projectMockDependencies);
+    when(projectMock.getDirectDependencies()).thenReturn(projectMockDependencies);
   }
 
   @Test

--- a/mule-packager/src/test/java/util/ResolverTestHelper.java
+++ b/mule-packager/src/test/java/util/ResolverTestHelper.java
@@ -204,7 +204,7 @@ public class ResolverTestHelper {
       throws ProjectBuildingException {
     for (Map.Entry entry : projectStructure.entrySet()) {
       Project projectMock = mock(Project.class);
-      when(projectMock.getDependencies()).thenReturn((List<ArtifactCoordinates>) entry.getValue());
+      when(projectMock.getDirectDependencies()).thenReturn((List<ArtifactCoordinates>) entry.getValue());
       when(projectBuilderMock.buildProject((ArtifactCoordinates) entry.getKey())).thenReturn(projectMock);
     }
   }


### PR DESCRIPTION
Using getArtifacts instead of getDependencies because returns all dependencies including the transitive ones.

https://maven.apache.org/ref/3.2.3/apidocs/org/apache/maven/project/MavenProject.html#getArtifacts()