### PR TITLE
W-10877491: Remove remaining deps that are not in the public repo from the extension-model-loader

### DIFF
--- a/mule-extension-model-loader/pom.xml
+++ b/mule-extension-model-loader/pom.xml
@@ -36,12 +36,18 @@
         <dependency>
             <groupId>com.mulesoft.anypoint</groupId>
             <artifactId>api-gateway-api</artifactId>
-            <version>1.3.0</version>
+            <version>1.5.0-20220125</version>
         </dependency>
          <dependency>
             <groupId>com.mulesoft.mule.runtime</groupId>
             <artifactId>mule-core-ee</artifactId>
             <version>${mule.version}</version>
+            <exclusions>
+            	<exclusion>
+            		<groupId>com.mulesoft.licm</groupId>
+            		<artifactId>licm</artifactId>
+            	</exclusion>
+            </exclusions>
         </dependency>
          <dependency>
                 <groupId>com.mulesoft.anypoint</groupId>
@@ -49,11 +55,21 @@
 	            <version>${mule.version}</version>
 	        </dependency>
 
+            <dependency>
+                <groupId>org.mule.runtime</groupId>
+                <artifactId>mule-module-extensions-xml-support</artifactId>
+                <version>${mule.version}</version>
+            </dependency>
          <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-module-javaee</artifactId>
 			<version>${mule.version}</version>
         </dependency>
+                    <dependency>
+                <groupId>org.mule.runtime</groupId>
+                <artifactId>mule-module-tls</artifactId>
+                <version>${mule.version}</version>
+            </dependency>
         <dependency>
             <groupId>com.mulesoft.mule.runtime.modules</groupId>
             <artifactId>mule-runtime-ee-extension-model</artifactId>
@@ -64,13 +80,7 @@
             <artifactId>mule-module-deployment-model-impl</artifactId>
             <version>${mule.version}</version>
         </dependency>
-        <!-- For now adding TC in order to get all extension models providers -->
-        <dependency>
-            <groupId>org.mule.tooling</groupId>
-            <artifactId>mule-runtime-tooling-client</artifactId>
-            <version>4.5.0-20211201</version>
-            <scope>provided</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.mule</groupId>
             <artifactId>mule-maven-client-impl</artifactId>

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/DefaultExtensionModelLoader.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/DefaultExtensionModelLoader.java
@@ -11,8 +11,10 @@ import org.mule.runtime.container.internal.ContainerClassLoaderFactory;
 import org.mule.runtime.container.internal.DefaultModuleRepository;
 import org.mule.runtime.container.internal.JreModuleDiscoverer;
 import org.mule.runtime.container.internal.ModuleDiscoverer;
+import org.mule.runtime.core.api.extension.MuleExtensionModelProvider;
 import org.mule.runtime.deployment.model.api.artifact.extension.ExtensionModelDiscoverer;
 import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
+import org.mule.runtime.extension.api.extension.XmlSdk1ExtensionModelProvider;
 import org.mule.runtime.module.artifact.api.classloader.ArtifactClassLoader;
 import org.mule.tooling.api.ExtensionModelLoader;
 
@@ -60,6 +62,9 @@ public class DefaultExtensionModelLoader implements ExtensionModelLoader {
   @Override
   public Set<ExtensionModel> getRuntimeExtensionModels() {
     Set<ExtensionModel> runtimeExtensionModels = extensionModelDiscoverer.discoverRuntimeExtensionModels();
+    runtimeExtensionModels.add(MuleExtensionModelProvider.getExtensionModel());
+    runtimeExtensionModels.add(XmlSdk1ExtensionModelProvider.getExtensionModel());
+    runtimeExtensionModels.add(MuleExtensionModelProvider.getTlsExtensionModel());
     runtimeExtensionModels.add(MuleEeExtensionModelProvider.getExtensionModel());
     runtimeExtensionModels.add(BatchExtensionModelProvider.getExtensionModel());
     runtimeExtensionModels.add(BtiExtensionModelProvider.getExtensionModel());


### PR DESCRIPTION
In order to remove tooling-client dep, I added manually the ext models that were not added. Now, it's the same that introspection service : https://github.com/mulesoft/mule-ang-introspection-service/blob/9636fd82f993c6076220fd1a93926469c1268f2c/introspector/src/main/java/com/mulesoft/runtime/ang/introspector/extension/DefaultExtensionModelLoader.java#L44