### PR TITLE
managing default empty value for the RTF inbound URL

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/model/anypoint/Inbound.java
+++ b/mule-deployer/src/main/java/org/mule/tools/model/anypoint/Inbound.java
@@ -13,8 +13,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 public class Inbound {
 
-  @Parameter
-  protected String publicUrl;
+  @Parameter(defaultValue = "")
+  protected String publicUrl = "";
 
 
   public String getPublicUrl() {


### PR DESCRIPTION
This fix is to let the RTF deploy action to manage the possibility not to set an inbound URL. This is needed in RTF BYOK (eg eks) when you want to deploy an API at process or system layer. 
By leaving the configuration empty like this:
```
<http>										
   <inbound>		
      <publicUrl></publicUrl>									 															 
   </inbound>
</http>
```
the behaviour should be that no mapping will be created in the RTF application deploy.