### PR TITLE
W-11025088: cherrypick

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
+++ b/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
@@ -14,6 +14,7 @@ import org.mule.tools.client.cloudhub.CloudHubClient;
 import org.mule.tools.client.cloudhub.model.Application;
 import org.mule.tools.client.cloudhub.model.Environment;
 import org.mule.tools.client.cloudhub.model.MuleVersion;
+import org.mule.tools.client.cloudhub.model.SupportedVersion;
 import org.mule.tools.client.cloudhub.model.WorkerType;
 import org.mule.tools.client.cloudhub.model.Workers;
 import org.mule.tools.client.core.exception.DeploymentException;
@@ -38,6 +39,7 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
   private static final String DEFAULT_CH_WORKER_TYPE = "Micro";
   private static final Integer DEFAULT_CH_WORKERS = 1;
   private static final Long DEFAULT_CLOUDHUB_DEPLOYMENT_TIMEOUT = 600000L;
+  public static final String OBJECT_STOREV1 = "objectStoreV1";
 
   private final DeployerLog log;
   private final CloudHubDeployment deployment;
@@ -256,8 +258,9 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
 
   private void configureObjectStore() {
     if (deployment.getObjectStoreV2() == null) {
-      Environment environment = client.getEnvironment();
-      deployment.setObjectStoreV2(!environment.getObjectStoreV1Enabled());
+      deployment.setObjectStoreV2(!(client.getSupportedMuleVersions().stream()
+          .anyMatch(version -> version.getVersion().equals(deployment.getMuleVersion().get())
+              && version.getLatestUpdate().getFlags().get(OBJECT_STOREV1))));
     }
   }
 

--- a/mule-deployer/src/test/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployerTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployerTest.java
@@ -20,6 +20,8 @@ import org.mule.tools.client.arm.model.UserInfo;
 import org.mule.tools.client.cloudhub.model.Application;
 import org.mule.tools.client.cloudhub.CloudHubClient;
 import org.mule.tools.client.cloudhub.model.Environment;
+import org.mule.tools.client.cloudhub.model.LatestUpdate;
+import org.mule.tools.client.cloudhub.model.SupportedVersion;
 import org.mule.tools.client.core.exception.DeploymentException;
 import org.mule.tools.model.anypoint.CloudHubDeployment;
 import org.mule.tools.utils.DeployerLog;
@@ -27,7 +29,9 @@ import org.mule.tools.verification.cloudhub.CloudHubDeploymentVerification;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -333,7 +337,7 @@ public class CloudHubArtifactDeployerTest {
     when(clientMock.isDomainAvailable(any())).thenReturn(true);
 
     Environment mockEnvironment = mock(Environment.class);
-    when(mockEnvironment.getObjectStoreV1Enabled()).thenReturn(true);
+    when(clientMock.getSupportedMuleVersions()).thenReturn(getObjectStoreV1Enabled(true, "4.0.0"));
 
     when(clientMock.getEnvironment()).thenReturn(mockEnvironment);
 
@@ -360,14 +364,27 @@ public class CloudHubArtifactDeployerTest {
     when(clientMock.isDomainAvailable(any())).thenReturn(true);
 
     Environment mockEnvironment = mock(Environment.class);
-    when(mockEnvironment.getObjectStoreV1Enabled()).thenReturn(false);
 
     when(clientMock.getEnvironment()).thenReturn(mockEnvironment);
+    when(clientMock.getSupportedMuleVersions()).thenReturn(getObjectStoreV1Enabled(false, "4.0.0"));
 
     cloudHubArtifactDeployer.deployApplication();
 
     ArgumentCaptor<Application> applicationCaptor = ArgumentCaptor.forClass(Application.class);
     verify(clientMock).createApplication(applicationCaptor.capture(), any());
     assertThat("ObjectStoreV1 must be true", applicationCaptor.getValue().getObjectStoreV1(), equalTo(false));
+  }
+
+  private List<SupportedVersion> getObjectStoreV1Enabled(boolean enabled, String muleVersion) {
+    List<SupportedVersion> supportedVersions = new ArrayList<SupportedVersion>();
+    SupportedVersion version = new SupportedVersion();
+    LatestUpdate update = new LatestUpdate();
+    HashMap<String, Boolean> flags = new HashMap<String, Boolean>();
+    flags.put(CloudHubArtifactDeployer.OBJECT_STOREV1, enabled);
+    update.setFlags(flags);
+    version.setLatestUpdate(update);
+    version.setVersion(muleVersion);
+    supportedVersions.add(version);
+    return supportedVersions;
   }
 }


### PR DESCRIPTION

* W-11025088:Objectstore error while deploying to cloudhub

We are getting the default value for object store from the property
objectStoreV1Enabled given by this endpoint
https://anypoint.mulesoft.com/cloudhub/api/buildinfo/environment
That is always true for CH, we need to extract this value from the
runtime version
