### PR TITLE
cherrypick W-11119054

### DIFF
--- a/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/InstallMojoTest.java
+++ b/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/InstallMojoTest.java
@@ -36,6 +36,7 @@ public class InstallMojoTest extends MojoTest {
   private static final String MULE_APPLICATION_CLASSIFIER_LIGHT_PACKAGE = "mule-application-light-package";
   private static final String MULE_APPLICATION_WITH_PLUGIN_DEP = "simple-app-with-lib";
   private static final String MULE_PLUGIN = "simple-lib";
+  private static final String INCOMPLETE_PLUGIN = "incomplete-mule-plugin";
 
   public InstallMojoTest() {
     this.goal = INSTALL;
@@ -238,6 +239,17 @@ public class InstallMojoTest extends MojoTest {
 
     verifier.deleteArtifacts(GROUP_ID, MULE_APPLICATION_WITH_PLUGIN_DEP, VERSION);
     verifierPlugin.deleteArtifacts(GROUP_ID, MULE_PLUGIN, VERSION);
+
+    verifierPlugin.executeGoal(INSTALL);
+    verifier.executeGoal(INSTALL);
+    verifier.verifyErrorFreeLog();
+  }
+
+  @Test
+  public void testInstallIncompletePlugin() throws IOException, VerificationException {
+    File pluginBaseDirectory = builder.createProjectBaseDir(INCOMPLETE_PLUGIN, this.getClass());
+
+    Verifier verifierPlugin = buildVerifier(pluginBaseDirectory);
 
     verifierPlugin.executeGoal(INSTALL);
     verifier.executeGoal(INSTALL);

--- a/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/mule-artifact.json
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/mule-artifact.json
@@ -1,0 +1,13 @@
+{
+	"minMuleVersion": "4.4.0",
+	"classLoaderModelLoaderDescriptor": {
+		"id": "mule",
+		"attributes": {
+			"exportedPackages": [],
+			"exportedResources": [
+				"simple-lib.xml"
+			]
+
+		}
+	}
+}

--- a/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.mycompany</groupId>
+	<artifactId>simple-lib-3</artifactId>
+	<version>1.0.10-SNAPSHOT</version>
+	<packaging>mule-application</packaging>
+
+	<name>simple-plugin</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+		<app.runtime>4.4.0-20220420</app.runtime>
+		<mule.maven.plugin.version>${muleMavenPluginVersion}</mule.maven.plugin.version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.0.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.mule.tools.maven</groupId>
+				<artifactId>mule-maven-plugin</artifactId>
+				<version>${mule.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<classifier>mule-plugin</classifier>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mule.connectors</groupId>
+			<artifactId>mule-http-connector</artifactId>
+			<version>1.6.0</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.mule.connectors</groupId>
+			<artifactId>mule-sockets-connector</artifactId>
+			<version>1.2.2</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>anypoint-exchange-v2</id>
+			<name>Anypoint Exchange</name>
+			<url>https://maven.anypoint.mulesoft.com/api/v2/maven</url>
+			<layout>default</layout>
+		</repository>
+		<repository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<layout>default</layout>
+		</repository>
+		<repository>
+			<id>anypoint-exchange-v3</id>
+			<name>Anypoint Exchange V3</name>
+			<url>https://maven.anypoint.mulesoft.com/api/v3/maven</url>
+			<layout>default</layout>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<layout>default</layout>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/src/main/mule/simple-lib.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/src/main/mule/simple-lib.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core"
+  xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+
+  
+  <flow name="common-flow">
+   <http:listener doc:name="Listener" doc:id="a872dae1-a43d-4f88-ab24-6d12569fc746" config-ref="commonListenerConfig" path="/"/>
+    <http:request method="GET" url="#[vars.livenessEndpoint]" followRedirects="true"  doc:name="HTTP GET to dependency" responseTimeout="#[${deps.alive.timeoutMillis}]">
+      <http:response-validator>
+        <http:success-status-code-validator values="200..299"/>
+      </http:response-validator>
+    </http:request>
+  </flow>
+
+
+
+</mule>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/src/test/resources/log4j2-test.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/src/test/resources/log4j2-test.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%-5p %d [%t] %c: %m%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <!-- Http Logger shows wire traffic on DEBUG -->
+        <!--AsyncLogger name="org.mule.service.http.impl.service.HttpMessageLogger" level="DEBUG"/-->
+        <AsyncLogger name="org.mule.service.http" level="WARN"/>
+        <AsyncLogger name="org.mule.extension.http" level="WARN"/>
+
+        <!-- Reduce startup noise -->
+        <AsyncLogger name="com.mulesoft.mule.runtime.plugin" level="WARN"/>
+        <AsyncLogger name="org.mule.maven.client" level="WARN"/>
+        <AsyncLogger name="org.mule.runtime.core.internal.util" level="WARN"/>
+        <AsyncLogger name="org.quartz" level="WARN"/>
+        <AsyncLogger name="org.mule.munit.plugins.coverage.server" level="WARN"/>
+
+        <!-- Mule logger -->
+        <AsyncLogger name="org.mule.runtime.core.internal.processor.LoggerMessageProcessor" level="INFO"/>
+
+        <AsyncRoot level="INFO">
+            <AppenderRef ref="Console"/>
+        </AsyncRoot>
+    </Loggers>
+
+</Configuration>

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
@@ -30,6 +30,7 @@ import org.mule.tools.api.packager.sources.MuleContentGenerator;
 import org.mule.tools.api.packager.structure.ProjectStructure;
 import org.mule.tooling.api.AstGenerator;
 import org.mule.tooling.api.ConfigurationException;
+import static org.mule.tools.api.packager.packaging.Classifier.MULE_PLUGIN;
 
 /**
  * @author Mulesoft Inc.
@@ -105,7 +106,8 @@ public class CompileMojo extends AbstractMuleMojo {
 
     ArtifactAst artifactAST = astGenerator.generateAST(contentResolver.getConfigs(), projectStructure.getConfigsPath());
     String skipASTValidation = System.getProperty(SKIP_AST_VALIDATION);
-    if (artifactAST != null && (skipASTValidation == null || skipASTValidation.equals("false"))) {
+    if (artifactAST != null && !this.getClassifier().equalsIgnoreCase(MULE_PLUGIN.toString())
+        && (skipASTValidation == null || skipASTValidation.equals("false"))) {
       ArrayList<ValidationResultItem> warnings = astGenerator.validateAST(artifactAST);
       for (ValidationResultItem warning : warnings) {
         getLog().warn(warning.getMessage());


### PR DESCRIPTION
…ule (#573)

Imported global configurations and error handlers from a Mule library
style plugins broken with Mule Maven Plugin 3.6.0+
We should avoid ast validation for app that are packaged as
mule-plugins. Because those apps can be incomplete and only work when
they are used in a specific context