### PR TITLE
W-11272161: Maven encrypted secret is not supported by Mule Maven Plugin

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/model/anypoint/DeploymentConfigurator.java
+++ b/mule-deployer/src/main/java/org/mule/tools/model/anypoint/DeploymentConfigurator.java
@@ -46,6 +46,8 @@ public class DeploymentConfigurator {
 
   private final DeployerLog log;
   private AnypointDeployment anypointConfiguration;
+  private final String DEFUALT_GRANT_TYPE = "client_credentials";
+  private final String CONNECTED_APPS_USER = "~~~Client~~~";
 
   public DeploymentConfigurator(AnypointDeployment anypointConfiguration, DeployerLog log) {
     this.anypointConfiguration = anypointConfiguration;
@@ -127,9 +129,20 @@ public class DeploymentConfigurator {
       }
       // Decrypting Maven server, in case of plain text passwords returns the same
       serverObject = decrypter.decrypt(new DefaultSettingsDecryptionRequest(serverObject)).getServer();
+
       if (StringUtils.isNotEmpty(anypointConfiguration.getUsername())
-          || StringUtils.isNotEmpty(anypointConfiguration.getPassword())) {
+          || StringUtils.isNotEmpty(anypointConfiguration.getPassword())
+          || StringUtils.isNotEmpty(anypointConfiguration.getPassword())
+          || StringUtils.isNotEmpty(anypointConfiguration.getConnectedAppClientId())
+          || StringUtils.isNotEmpty(anypointConfiguration.getConnectedAppClientSecret())) {
         log.warn("Both server and credentials are configured. Using plugin configuration credentials.");
+      } else if (serverObject.getUsername().equals(CONNECTED_APPS_USER)) {
+        String[] clientApplicationCredentials = StringUtils.split(serverObject.getPassword(), "~?~");
+        anypointConfiguration.setConnectedAppClientId(clientApplicationCredentials[0]);
+        anypointConfiguration.setConnectedAppClientSecret(clientApplicationCredentials[1]);
+        if (StringUtils.isEmpty(anypointConfiguration.getConnectedAppGrantType())) {
+          anypointConfiguration.setConnectedAppGrantType(DEFUALT_GRANT_TYPE);
+        }
       } else {
         anypointConfiguration.setUsername(serverObject.getUsername());
         anypointConfiguration.setPassword(serverObject.getPassword());

--- a/mule-deployer/src/test/java/org/mule/tools/model/anypoint/DeploymentConfiguratorTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/model/anypoint/DeploymentConfiguratorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Mule ESB Maven Tools
+ * <p>
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * <p>
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.tools.model.anypoint;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.crypto.SettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecryptionResult;
+import org.junit.Test;
+import org.mule.tools.utils.DeployerLog;
+
+
+public class DeploymentConfiguratorTest {
+
+  private static final String CONNECTED_APPS_USER = "~~~Client~~~";
+  private static final String CLIENT_ID = "clientId";
+  private static final String CLIENT_SECRET = "clientSecret";
+  private static final String CLOUDHUB_SERVER = "cloudhubServer";
+  Server server = new Server();
+
+  @Test
+  public void configuratorShouldGetConnectedAppCredentialsFromServertest() throws MojoExecutionException {
+    DeployerLog log = mock(DeployerLog.class);
+    AnypointDeployment deployment = new CloudHubDeployment();
+    deployment.setServer(CLOUDHUB_SERVER);
+    DeploymentConfigurator configurator = new DeploymentConfigurator(deployment, log);
+    server.setId(CLOUDHUB_SERVER);
+    server.setUsername(CONNECTED_APPS_USER);
+    server.setPassword(CLIENT_ID + "~?~" + CLIENT_SECRET);
+    SettingsDecrypter decrypter = new SettingsDecrypter() {
+
+      @Override
+      public SettingsDecryptionResult decrypt(SettingsDecryptionRequest request) {
+        SettingsDecryptionResult result = mock(SettingsDecryptionResult.class);
+        when(result.getServer()).thenReturn(server);
+        return result;
+      }
+    };
+    Settings settings = new Settings();
+
+
+    settings.addServer(server);
+    configurator.initializeEnvironment(settings, decrypter);
+    assertTrue(deployment.getConnectedAppClientId().equals(CLIENT_ID));
+    assertTrue(deployment.getConnectedAppClientSecret().equals(CLIENT_SECRET));
+
+
+  }
+
+}


### PR DESCRIPTION
The problem was that the credentials defined as maven server were not
used in amc deployments even when the user was ~~~client~~~ (that is the
convention for Connected-apps credentials)