### PR TITLE
W-11286314:AST generation fails when having deps with provided scope

### DIFF
--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/pom.xml
@@ -41,12 +41,14 @@
 			<artifactId>mule-http-connector</artifactId>
 			<version>1.6.0</version>
 			<classifier>mule-plugin</classifier>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mule.connectors</groupId>
 			<artifactId>mule-sockets-connector</artifactId>
 			<version>1.2.2</version>
 			<classifier>mule-plugin</classifier>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin.my.unit</groupId>

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
@@ -69,7 +69,6 @@ public class AstGenerator {
         });
       } else {
         if (artifact.getType().equals("jar")) {
-          mavenClient.resolveBundleDescriptor(toBundleDescriptor(dependency));
           try {
             classRealm.addURL(mavenClient.resolveBundleDescriptor(toBundleDescriptor(dependency)).getBundleUri().toURL());
           } catch (MalformedURLException e1) {

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
@@ -12,25 +12,15 @@ package org.mule.tools.maven.mojo;
 
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Paths;
-import java.util.ArrayList;
 
-import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.mule.runtime.ast.api.ArtifactAst;
-import org.mule.runtime.ast.api.validation.ValidationResultItem;
-import org.mule.tools.api.packager.sources.MuleArtifactContentResolver;
 import org.mule.tools.api.packager.sources.MuleContentGenerator;
-import org.mule.tools.api.packager.structure.ProjectStructure;
-import org.mule.tooling.api.AstGenerator;
-import org.mule.tooling.api.ConfigurationException;
-import static org.mule.tools.api.packager.packaging.Classifier.MULE_PLUGIN;
+
 
 /**
  * @author Mulesoft Inc.
@@ -44,73 +34,18 @@ public class CompileMojo extends AbstractMuleMojo {
   @Component
   private PluginDescriptor descriptor;
 
-
-  private static final String RUNTIME_AST_VERSION = "4.4.0";
-  private static final String MULE_POLICY = "mule-policy";
-  private static final String MULE_DOMAIN = "mule-domain";
-  private static final String SKIP_AST = "skipAST";
-  private static final String SKIP_AST_VALIDATION = "skipASTValidation";
-
   @Override
   public void doExecute() throws MojoFailureException {
     getLog().debug("Generating mule source code...");
     try {
       ((MuleContentGenerator) getContentGenerator()).createMuleSrcFolderContent();
-      String skipAST = System.getProperty(SKIP_AST);
-      // apps in domains are not currently supported MMP-588
-      if ((skipAST == null || skipAST.equals("false")) && !project.getPackaging().equals(MULE_POLICY) && !hasDomain()) {
-        ArtifactAst artifact = getArtifactAst();
-        if (artifact != null) {
-          ((MuleContentGenerator) getContentGenerator()).createAstFile(serialize(artifact));
-        }
-      }
-    } catch (IllegalArgumentException | IOException | ConfigurationException e) {
+    } catch (IllegalArgumentException | IOException e) {
       throw new MojoFailureException("Fail to compile", e);
     }
-  }
-
-
-  private boolean hasDomain() {
-    if (project.getDependencies() != null) {
-      for (Dependency dependency : project.getDependencies()) {
-        if (dependency.getClassifier() != null && dependency.getClassifier().equals(MULE_DOMAIN)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  public InputStream serialize(ArtifactAst artifact) {
-    return AstGenerator.serialize(artifact);
   }
 
   @Override
   public String getPreviousRunPlaceholder() {
     return "MULE_MAVEN_PLUGIN_COMPILE_PREVIOUS_RUN_PLACEHOLDER";
-  }
-
-  public ArtifactAst getArtifactAst() throws IOException, ConfigurationException {
-    descriptor.getClassRealm()
-        .addURL(project.getBasedir().toPath().resolve("src").resolve("main").resolve("resources").toUri().toURL());
-    AstGenerator astGenerator = new AstGenerator(getAetherMavenClient(), RUNTIME_AST_VERSION,
-                                                 project.getArtifacts(), Paths.get(project.getBuild().getDirectory()),
-                                                 descriptor.getClassRealm());
-    ProjectStructure projectStructure = new ProjectStructure(projectBaseFolder.toPath(), false);
-    MuleArtifactContentResolver contentResolver =
-        new MuleArtifactContentResolver(new ProjectStructure(projectBaseFolder.toPath(), false),
-                                        getProjectInformation().getEffectivePom(),
-                                        getProjectInformation().getProject().getBundleDependencies());
-
-    ArtifactAst artifactAST = astGenerator.generateAST(contentResolver.getConfigs(), projectStructure.getConfigsPath());
-    String skipASTValidation = System.getProperty(SKIP_AST_VALIDATION);
-    if (artifactAST != null && !this.getClassifier().equalsIgnoreCase(MULE_PLUGIN.toString())
-        && (skipASTValidation == null || skipASTValidation.equals("false"))) {
-      ArrayList<ValidationResultItem> warnings = astGenerator.validateAST(artifactAST);
-      for (ValidationResultItem warning : warnings) {
-        getLog().warn(warning.getMessage());
-      }
-    }
-    return artifactAST;
   }
 }

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/ProcessClassesMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/ProcessClassesMojo.java
@@ -10,12 +10,31 @@
 
 package org.mule.tools.maven.mojo;
 
+import static org.mule.tools.api.packager.packaging.Classifier.MULE_PLUGIN;
 import static org.mule.tools.maven.mojo.model.lifecycle.MavenLifecyclePhase.VALIDATE;
+
+import org.mule.runtime.ast.api.ArtifactAst;
+import org.mule.runtime.ast.api.validation.ValidationResultItem;
+import org.mule.tooling.api.AstGenerator;
+import org.mule.tooling.api.ConfigurationException;
 import org.mule.tools.api.exception.ValidationException;
+import org.mule.tools.api.packager.sources.MuleArtifactContentResolver;
+import org.mule.tools.api.packager.sources.MuleContentGenerator;
+import org.mule.tools.api.packager.structure.ProjectStructure;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -30,9 +49,30 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
     requiresDependencyResolution = ResolutionScope.TEST)
 public class ProcessClassesMojo extends AbstractMuleMojo {
 
+  @Component
+  private PluginDescriptor descriptor;
+  private static final String RUNTIME_AST_VERSION = "4.4.0";
+  private static final String MULE_POLICY = "mule-policy";
+  private static final String MULE_DOMAIN = "mule-domain";
+  private static final String SKIP_AST = "skipAST";
+  private static final String SKIP_AST_VALIDATION = "skipASTValidation";
+
   @Override
-  public void doExecute() throws MojoExecutionException {
+  public void doExecute() throws MojoExecutionException, MojoFailureException {
     getLog().debug("Generating process-classes code...");
+    try {
+
+      String skipAST = System.getProperty(SKIP_AST);
+      // apps in domains are not currently supported MMP-588
+      if ((skipAST == null || skipAST.equals("false")) && !project.getPackaging().equals(MULE_POLICY) && !hasDomain()) {
+        ArtifactAst artifact = getArtifactAst();
+        if (artifact != null) {
+          ((MuleContentGenerator) getContentGenerator()).createAstFile(serialize(artifact));
+        }
+      }
+    } catch (IllegalArgumentException | IOException | ConfigurationException e) {
+      throw new MojoFailureException("Fail to compile", e);
+    }
     try {
       getContentGenerator().copyDescriptorFile();
       if (!skipValidation) {
@@ -49,6 +89,45 @@ public class ProcessClassesMojo extends AbstractMuleMojo {
   @Override
   public String getPreviousRunPlaceholder() {
     return "MULE_MAVEN_PLUGIN_PROCESS_CLASSES_PREVIOUS_RUN_PLACEHOLDER";
+  }
+
+  public ArtifactAst getArtifactAst() throws IOException, ConfigurationException {
+    descriptor.getClassRealm()
+        .addURL(project.getBasedir().toPath().resolve("src").resolve("main").resolve("resources").toUri().toURL());
+    AstGenerator astGenerator = new AstGenerator(getAetherMavenClient(), RUNTIME_AST_VERSION,
+                                                 project.getArtifacts(), Paths.get(project.getBuild().getDirectory()),
+                                                 descriptor.getClassRealm());
+    ProjectStructure projectStructure = new ProjectStructure(projectBaseFolder.toPath(), false);
+    MuleArtifactContentResolver contentResolver =
+        new MuleArtifactContentResolver(new ProjectStructure(projectBaseFolder.toPath(), false),
+                                        getProjectInformation().getEffectivePom(),
+                                        getProjectInformation().getProject().getBundleDependencies());
+
+    ArtifactAst artifactAST = astGenerator.generateAST(contentResolver.getConfigs(), projectStructure.getConfigsPath());
+    String skipASTValidation = System.getProperty(SKIP_AST_VALIDATION);
+    if (artifactAST != null && !this.getClassifier().equalsIgnoreCase(MULE_PLUGIN.toString())
+        && (skipASTValidation == null || skipASTValidation.equals("false"))) {
+      ArrayList<ValidationResultItem> warnings = astGenerator.validateAST(artifactAST);
+      for (ValidationResultItem warning : warnings) {
+        getLog().warn(warning.getMessage());
+      }
+    }
+    return artifactAST;
+  }
+
+  private boolean hasDomain() {
+    if (project.getDependencies() != null) {
+      for (Dependency dependency : project.getDependencies()) {
+        if (dependency.getClassifier() != null && dependency.getClassifier().equals(MULE_DOMAIN)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  public InputStream serialize(ArtifactAst artifact) {
+    return AstGenerator.serialize(artifact);
   }
 
 }

--- a/mule-maven-plugin/src/test/java/org/mule/tools/maven/mojo/CompileMojoTest.java
+++ b/mule-maven-plugin/src/test/java/org/mule/tools/maven/mojo/CompileMojoTest.java
@@ -19,11 +19,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.StringInputStream;
 import org.junit.Before;
 import org.junit.Test;
-import org.mule.runtime.ast.api.ArtifactAst;
-import org.mule.tooling.api.AstGenerator;
 import org.mule.tooling.api.ConfigurationException;
 import org.mule.tools.api.packager.sources.MuleContentGenerator;
 
@@ -56,16 +53,12 @@ public class CompileMojoTest extends AbstractMuleMojoTest {
     MuleContentGenerator contentGeneratorMock = mock(MuleContentGenerator.class);
     InputStream stream = new StringInputStream("");
     doReturn(contentGeneratorMock).when(mojoMock).getContentGenerator();
-    ArtifactAst artifactAst = mock(ArtifactAst.class);
-    doReturn(artifactAst).when(mojoMock).getArtifactAst();
-    doReturn(stream).when(mojoMock).serialize(artifactAst);
     doCallRealMethod().when(mojoMock).execute();
     doCallRealMethod().when(mojoMock).doExecute();
     mojoMock.execute();
 
-    verify(mojoMock, times(2)).getContentGenerator();
+    verify(mojoMock, times(1)).getContentGenerator();
     verify(contentGeneratorMock, times(1)).createMuleSrcFolderContent();
-    verify(contentGeneratorMock, times(1)).createAstFile(stream);
   }
 
   @Test(expected = MojoFailureException.class)

--- a/mule-maven-plugin/src/test/java/org/mule/tools/maven/mojo/CompileMojoTest.java
+++ b/mule-maven-plugin/src/test/java/org/mule/tools/maven/mojo/CompileMojoTest.java
@@ -51,7 +51,6 @@ public class CompileMojoTest extends AbstractMuleMojoTest {
   public void execute()
       throws FileNotFoundException, ConfigurationException, IOException, MojoExecutionException, MojoFailureException {
     MuleContentGenerator contentGeneratorMock = mock(MuleContentGenerator.class);
-    InputStream stream = new StringInputStream("");
     doReturn(contentGeneratorMock).when(mojoMock).getContentGenerator();
     doCallRealMethod().when(mojoMock).execute();
     doCallRealMethod().when(mojoMock).doExecute();


### PR DESCRIPTION
we should move the AST generation to the process-classes phase. Generating it after compile phase will allow us to have all the dependencies resolved (including transitive ones and those with "provided" or "runtime" scope). Also if the app is already compiled we can avoid the temporary app for obtaining the extension models. 
According to maven, process-classes phase is meant for:  
`post-process the generated files from compilation, for example to do bytecode enhancement on Java classes`
I think this is the right phase to do this if we see AST generation as a post process that takes the compiled resources and uses them to generate an enhanced representation of the app.