### PR TITLE
Disable default CloudHub log4j2 settings when deploying applications

### DIFF
--- a/build.jenkinsfile
+++ b/build.jenkinsfile
@@ -13,7 +13,7 @@ def pipelineParams = [
   "jdk": params.JDK,
   "maven": params.maven,
   "projectKey": "mule-maven-plugin",
-  "protectedBranches" : ["support/3.x", "support/3.4.x", "support/3.3.x", "support/2.x"]
+  "protectedBranches" : ["support/3.x", "support/3.6.x", "support/3.4.x", "support/3.3.x", "support/2.x"]
 ]
 
 build(pipelineParams)

--- a/mule-artifact-it/mule-deployer-it/pom.xml
+++ b/mule-artifact-it/mule-deployer-it/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-it</artifactId>
-        <version>3.6.2-SNAPSHOT</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-artifact-it/mule-deployer-it/pom.xml
+++ b/mule-artifact-it/mule-deployer-it/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-it</artifactId>
-        <version>3.6.1-SNAPSHOT</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-artifact-it/mule-deployer-it/pom.xml
+++ b/mule-artifact-it/mule-deployer-it/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-it</artifactId>
-        <version>3.6.0-SNAPSHOT</version>
+        <version>3.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-artifact-it/mule-deployer-it/pom.xml
+++ b/mule-artifact-it/mule-deployer-it/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-it</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>3.6.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-artifact-it/mule-packager-it/pom.xml
+++ b/mule-artifact-it/mule-packager-it/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-it</artifactId>
-        <version>3.6.2-SNAPSHOT</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-artifact-it/mule-packager-it/pom.xml
+++ b/mule-artifact-it/mule-packager-it/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-it</artifactId>
-        <version>3.6.1-SNAPSHOT</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-artifact-it/mule-packager-it/pom.xml
+++ b/mule-artifact-it/mule-packager-it/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-it</artifactId>
-        <version>3.6.0-SNAPSHOT</version>
+        <version>3.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-artifact-it/mule-packager-it/pom.xml
+++ b/mule-artifact-it/mule-packager-it/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-it</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>3.6.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/InstallMojoTest.java
+++ b/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/InstallMojoTest.java
@@ -36,6 +36,7 @@ public class InstallMojoTest extends MojoTest {
   private static final String MULE_APPLICATION_CLASSIFIER_LIGHT_PACKAGE = "mule-application-light-package";
   private static final String MULE_APPLICATION_WITH_PLUGIN_DEP = "simple-app-with-lib";
   private static final String MULE_PLUGIN = "simple-lib";
+  private static final String INCOMPLETE_PLUGIN = "incomplete-mule-plugin";
 
   public InstallMojoTest() {
     this.goal = INSTALL;
@@ -238,6 +239,17 @@ public class InstallMojoTest extends MojoTest {
 
     verifier.deleteArtifacts(GROUP_ID, MULE_APPLICATION_WITH_PLUGIN_DEP, VERSION);
     verifierPlugin.deleteArtifacts(GROUP_ID, MULE_PLUGIN, VERSION);
+
+    verifierPlugin.executeGoal(INSTALL);
+    verifier.executeGoal(INSTALL);
+    verifier.verifyErrorFreeLog();
+  }
+
+  @Test
+  public void testInstallIncompletePlugin() throws IOException, VerificationException {
+    File pluginBaseDirectory = builder.createProjectBaseDir(INCOMPLETE_PLUGIN, this.getClass());
+
+    Verifier verifierPlugin = buildVerifier(pluginBaseDirectory);
 
     verifierPlugin.executeGoal(INSTALL);
     verifier.executeGoal(INSTALL);

--- a/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/InstallMojoTest.java
+++ b/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/InstallMojoTest.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,6 +34,8 @@ public class InstallMojoTest extends MojoTest {
   private static final String MULE_APPLICATION_EXAMPLE_CLASSIFIER = "mule-application-example";
   private static final String MULE_APPLICATION_TEMPLATE_CLASSIFIER = "mule-application-template";
   private static final String MULE_APPLICATION_CLASSIFIER_LIGHT_PACKAGE = "mule-application-light-package";
+  private static final String MULE_APPLICATION_WITH_PLUGIN_DEP = "simple-app-with-lib";
+  private static final String MULE_PLUGIN = "simple-lib";
 
   public InstallMojoTest() {
     this.goal = INSTALL;
@@ -223,6 +226,22 @@ public class InstallMojoTest extends MojoTest {
 
     verifier.verifyErrorFreeLog();
     assertThat("Artifact was not installed in the .m2 repository", artifactFile.exists());
+  }
+
+  @Test
+  public void testInstallAppWithPluginDep() throws IOException, VerificationException {
+    File pluginBaseDirectory = builder.createProjectBaseDir(MULE_PLUGIN, this.getClass());
+    projectBaseDirectory = builder.createProjectBaseDir(MULE_APPLICATION_WITH_PLUGIN_DEP, this.getClass());
+
+    Verifier verifierPlugin = buildVerifier(pluginBaseDirectory);
+    verifier = buildVerifier(projectBaseDirectory);
+
+    verifier.deleteArtifacts(GROUP_ID, MULE_APPLICATION_WITH_PLUGIN_DEP, VERSION);
+    verifierPlugin.deleteArtifacts(GROUP_ID, MULE_PLUGIN, VERSION);
+
+    verifierPlugin.executeGoal(INSTALL);
+    verifier.executeGoal(INSTALL);
+    verifier.verifyErrorFreeLog();
   }
 
   @Test

--- a/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/mule-artifact.json
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/mule-artifact.json
@@ -1,0 +1,13 @@
+{
+	"minMuleVersion": "4.4.0",
+	"classLoaderModelLoaderDescriptor": {
+		"id": "mule",
+		"attributes": {
+			"exportedPackages": [],
+			"exportedResources": [
+				"simple-lib.xml"
+			]
+
+		}
+	}
+}

--- a/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.mycompany</groupId>
+	<artifactId>simple-lib-3</artifactId>
+	<version>1.0.10-SNAPSHOT</version>
+	<packaging>mule-application</packaging>
+
+	<name>simple-plugin</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+		<app.runtime>4.4.0-20220420</app.runtime>
+		<mule.maven.plugin.version>${muleMavenPluginVersion}</mule.maven.plugin.version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.0.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.mule.tools.maven</groupId>
+				<artifactId>mule-maven-plugin</artifactId>
+				<version>${mule.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<classifier>mule-plugin</classifier>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mule.connectors</groupId>
+			<artifactId>mule-http-connector</artifactId>
+			<version>1.6.0</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.mule.connectors</groupId>
+			<artifactId>mule-sockets-connector</artifactId>
+			<version>1.2.2</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>anypoint-exchange-v2</id>
+			<name>Anypoint Exchange</name>
+			<url>https://maven.anypoint.mulesoft.com/api/v2/maven</url>
+			<layout>default</layout>
+		</repository>
+		<repository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<layout>default</layout>
+		</repository>
+		<repository>
+			<id>anypoint-exchange-v3</id>
+			<name>Anypoint Exchange V3</name>
+			<url>https://maven.anypoint.mulesoft.com/api/v3/maven</url>
+			<layout>default</layout>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<layout>default</layout>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/src/main/mule/simple-lib.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/src/main/mule/simple-lib.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core"
+  xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+
+  
+  <flow name="common-flow">
+   <http:listener doc:name="Listener" doc:id="a872dae1-a43d-4f88-ab24-6d12569fc746" config-ref="commonListenerConfig" path="/"/>
+    <http:request method="GET" url="#[vars.livenessEndpoint]" followRedirects="true"  doc:name="HTTP GET to dependency" responseTimeout="#[${deps.alive.timeoutMillis}]">
+      <http:response-validator>
+        <http:success-status-code-validator values="200..299"/>
+      </http:response-validator>
+    </http:request>
+  </flow>
+
+
+
+</mule>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/src/test/resources/log4j2-test.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/incomplete-mule-plugin/src/test/resources/log4j2-test.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%-5p %d [%t] %c: %m%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <!-- Http Logger shows wire traffic on DEBUG -->
+        <!--AsyncLogger name="org.mule.service.http.impl.service.HttpMessageLogger" level="DEBUG"/-->
+        <AsyncLogger name="org.mule.service.http" level="WARN"/>
+        <AsyncLogger name="org.mule.extension.http" level="WARN"/>
+
+        <!-- Reduce startup noise -->
+        <AsyncLogger name="com.mulesoft.mule.runtime.plugin" level="WARN"/>
+        <AsyncLogger name="org.mule.maven.client" level="WARN"/>
+        <AsyncLogger name="org.mule.runtime.core.internal.util" level="WARN"/>
+        <AsyncLogger name="org.quartz" level="WARN"/>
+        <AsyncLogger name="org.mule.munit.plugins.coverage.server" level="WARN"/>
+
+        <!-- Mule logger -->
+        <AsyncLogger name="org.mule.runtime.core.internal.processor.LoggerMessageProcessor" level="INFO"/>
+
+        <AsyncRoot level="INFO">
+            <AppenderRef ref="Console"/>
+        </AsyncRoot>
+    </Loggers>
+
+</Configuration>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/mule-artifact.json
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/mule-artifact.json
@@ -1,0 +1,3 @@
+{
+  "minMuleVersion": "4.4.0"
+}

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/pom.xml
@@ -61,6 +61,12 @@
             <classifier>mule-plugin</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+			<groupId>org.wildfly</groupId>
+			<artifactId>wildfly-parent</artifactId>
+			<version>8.2.1.Final</version>
+			<type>pom</type>
+		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/pom.xml
@@ -41,12 +41,14 @@
 			<artifactId>mule-http-connector</artifactId>
 			<version>1.6.0</version>
 			<classifier>mule-plugin</classifier>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mule.connectors</groupId>
 			<artifactId>mule-sockets-connector</artifactId>
 			<version>1.2.2</version>
 			<classifier>mule-plugin</classifier>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin.my.unit</groupId>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>simple-app-with-lib</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>mule-application</packaging>
+
+	<name>simple-app-with-lib</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+		<app.runtime>4.4.0</app.runtime>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.0.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.mule.tools.maven</groupId>
+				<artifactId>mule-maven-plugin</artifactId>
+				<version>${muleMavenPluginVersion}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<classifier>mule-application</classifier>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mule.connectors</groupId>
+			<artifactId>mule-http-connector</artifactId>
+			<version>1.6.0</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.mule.connectors</groupId>
+			<artifactId>mule-sockets-connector</artifactId>
+			<version>1.2.2</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugin.my.unit</groupId>
+			<artifactId>simple-lib</artifactId>
+			<version>1.0.0</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>anypoint-exchange-v2</id>
+			<name>Anypoint Exchange</name>
+			<url>https://maven.anypoint.mulesoft.com/api/v2/maven</url>
+			<layout>default</layout>
+		</repository>
+		<repository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<layout>default</layout>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<layout>default</layout>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/pom.xml
@@ -54,6 +54,13 @@
 			<version>1.0.0</version>
 			<classifier>mule-plugin</classifier>
 		</dependency>
+        <dependency>
+            <groupId>com.mulesoft.munit</groupId>
+            <artifactId>munit-runner</artifactId>
+            <version>2.3.9</version>
+            <classifier>mule-plugin</classifier>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<repositories>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/src/main/mule/simple-app-with-lib.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/src/main/mule/simple-app-with-lib.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xmlns:http="http://www.mulesoft.org/schema/mule/http"
+	xmlns="http://www.mulesoft.org/schema/mule/core"
+	xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
 
   <import file="simple-lib.xml"/>
 
   <flow name="test-lib">
     <flow-ref name="common-flow"/>
   </flow>
+    <flow name="testing-transform-set-payload-validationFlow" doc:id="ccea05d4-3e8e-4e8a-9f43-f245158282e7" >
+		<ee:transform doc:name="Transform Message" doc:id="232cf3e8-ab0e-4363-8869-3c518a43e11e" >
+			<ee:message >
+				<ee:set-payload resource="dataweave/set-empty-payload.dwl" />
+			</ee:message>
+		</ee:transform>
+	</flow>
 
 </mule>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/src/main/mule/simple-app-with-lib.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/src/main/mule/simple-app-with-lib.xml
@@ -12,6 +12,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
     <flow-ref name="common-flow"/>
   </flow>
     <flow name="testing-transform-set-payload-validationFlow" doc:id="ccea05d4-3e8e-4e8a-9f43-f245158282e7" >
+    <parse-template doc:name="Parse Template" doc:id="2db3cec0-21c9-4f84-a776-ed56d63625d1" location="jboss-as-checkstyle/checkstyle.xml"/>
 		<ee:transform doc:name="Transform Message" doc:id="232cf3e8-ab0e-4363-8869-3c518a43e11e" >
 			<ee:message >
 				<ee:set-payload resource="dataweave/set-empty-payload.dwl" />

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/src/main/mule/simple-app-with-lib.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/src/main/mule/simple-app-with-lib.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+  <import file="simple-lib.xml"/>
+
+  <flow name="test-lib">
+    <flow-ref name="common-flow"/>
+  </flow>
+
+</mule>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/src/main/resources/dataweave/set-empty-payload.dwl
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/src/main/resources/dataweave/set-empty-payload.dwl
@@ -1,0 +1,5 @@
+%dw 2.0
+output application/json
+---
+{
+}

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-lib/mule-artifact.json
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-lib/mule-artifact.json
@@ -1,0 +1,3 @@
+{
+  "minMuleVersion": "4.4.0"
+}

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-lib/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-lib/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>simple-lib</artifactId>
+	<version>1.0.0</version>
+	<packaging>mule-application</packaging>
+
+	<name>simple-lib</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+		<app.runtime>4.4.0</app.runtime>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.0.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.mule.tools.maven</groupId>
+				<artifactId>mule-maven-plugin</artifactId>
+				<version>${muleMavenPluginVersion}</version>
+				<extensions>true</extensions>
+
+				<configuration>
+					<classifier>mule-plugin</classifier>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mule.connectors</groupId>
+			<artifactId>mule-http-connector</artifactId>
+			<version>1.6.0</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.mule.connectors</groupId>
+			<artifactId>mule-sockets-connector</artifactId>
+			<version>1.2.2</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>anypoint-exchange-v2</id>
+			<name>Anypoint Exchange</name>
+			<url>https://maven.anypoint.mulesoft.com/api/v2/maven</url>
+			<layout>default</layout>
+		</repository>
+		<repository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<layout>default</layout>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<layout>default</layout>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-lib/src/main/mule/simple-lib.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-lib/src/main/mule/simple-lib.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+  <flow name="common-flow">
+    <logger/>
+  </flow>
+
+</mule>

--- a/mule-artifact-it/pom.xml
+++ b/mule-artifact-it/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.1-SNAPSHOT</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-artifact-it/pom.xml
+++ b/mule-artifact-it/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>3.6.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-artifact-it/pom.xml
+++ b/mule-artifact-it/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.0-SNAPSHOT</version>
+        <version>3.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-artifact-it/pom.xml
+++ b/mule-artifact-it/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.2-SNAPSHOT</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-classloader-model/pom.xml
+++ b/mule-classloader-model/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.1-SNAPSHOT</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-classloader-model/pom.xml
+++ b/mule-classloader-model/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>3.6.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-classloader-model/pom.xml
+++ b/mule-classloader-model/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.0-SNAPSHOT</version>
+        <version>3.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-classloader-model/pom.xml
+++ b/mule-classloader-model/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.2-SNAPSHOT</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-deployer/pom.xml
+++ b/mule-deployer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.1-SNAPSHOT</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-deployer/pom.xml
+++ b/mule-deployer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>3.6.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-deployer/pom.xml
+++ b/mule-deployer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.0-SNAPSHOT</version>
+        <version>3.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-deployer/pom.xml
+++ b/mule-deployer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.2-SNAPSHOT</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-deployer/src/main/java/org/mule/tools/client/cloudhub/model/Application.java
+++ b/mule-deployer/src/main/java/org/mule/tools/client/cloudhub/model/Application.java
@@ -34,6 +34,7 @@ public class Application {
   private Boolean persistentQueues;
   private Boolean persistentQueuesEncryptionEnabled;
   private Boolean persistentQueuesEncrypted;
+  private Boolean loggingCustomLog4JEnabled;
   private Boolean monitoringEnabled;
   private Boolean monitoringAutoRestart;
   private Boolean staticIPsEnabled;
@@ -189,6 +190,14 @@ public class Application {
 
   public void setPersistentQueuesEncrypted(Boolean persistentQueuesEncrypted) {
     this.persistentQueuesEncrypted = persistentQueuesEncrypted;
+  }
+
+  public Boolean getLoggingCustomLog4JEnabled() {
+    return loggingCustomLog4JEnabled;
+  }
+
+  public void setLoggingCustomLog4JEnabled(Boolean loggingCustomLog4JEnabled) {
+    this.loggingCustomLog4JEnabled = loggingCustomLog4JEnabled;
   }
 
   public Boolean getMonitoringEnabled() {

--- a/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
+++ b/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
@@ -232,7 +232,7 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
 
     application.setObjectStoreV1(!deployment.getObjectStoreV2());
     application.setPersistentQueues(deployment.getPersistentQueues());
-    application.setLoggingCustomLog4JEnabled(deployment.getLoggingCustomLog4JEnabled());
+    application.setLoggingCustomLog4JEnabled(deployment.getCustomLog4J());
 
     return application;
   }

--- a/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
+++ b/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
@@ -232,6 +232,7 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
 
     application.setObjectStoreV1(!deployment.getObjectStoreV2());
     application.setPersistentQueues(deployment.getPersistentQueues());
+    application.setLoggingCustomLog4JEnabled(deployment.getLoggingCustomLog4JEnabled());
 
     return application;
   }

--- a/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
+++ b/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
@@ -14,6 +14,7 @@ import org.mule.tools.client.cloudhub.CloudHubClient;
 import org.mule.tools.client.cloudhub.model.Application;
 import org.mule.tools.client.cloudhub.model.Environment;
 import org.mule.tools.client.cloudhub.model.MuleVersion;
+import org.mule.tools.client.cloudhub.model.SupportedVersion;
 import org.mule.tools.client.cloudhub.model.WorkerType;
 import org.mule.tools.client.cloudhub.model.Workers;
 import org.mule.tools.client.core.exception.DeploymentException;
@@ -38,6 +39,7 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
   private static final String DEFAULT_CH_WORKER_TYPE = "Micro";
   private static final Integer DEFAULT_CH_WORKERS = 1;
   private static final Long DEFAULT_CLOUDHUB_DEPLOYMENT_TIMEOUT = 600000L;
+  public static final String OBJECT_STOREV1 = "objectStoreV1";
 
   private final DeployerLog log;
   private final CloudHubDeployment deployment;
@@ -256,8 +258,9 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
 
   private void configureObjectStore() {
     if (deployment.getObjectStoreV2() == null) {
-      Environment environment = client.getEnvironment();
-      deployment.setObjectStoreV2(!environment.getObjectStoreV1Enabled());
+      deployment.setObjectStoreV2(!(client.getSupportedMuleVersions().stream()
+          .anyMatch(version -> version.getVersion().equals(deployment.getMuleVersion().get())
+              && version.getLatestUpdate().getFlags().get(OBJECT_STOREV1))));
     }
   }
 

--- a/mule-deployer/src/main/java/org/mule/tools/model/anypoint/CloudHubDeployment.java
+++ b/mule-deployer/src/main/java/org/mule/tools/model/anypoint/CloudHubDeployment.java
@@ -38,6 +38,9 @@ public class CloudHubDeployment extends AnypointDeployment {
   protected Boolean persistentQueues = false;
 
   @Parameter
+  protected Boolean LoggingCustomLog4JEnabled = false;
+
+  @Parameter
   protected Integer waitBeforeValidation = 6000;
 
   @Parameter
@@ -106,6 +109,14 @@ public class CloudHubDeployment extends AnypointDeployment {
 
   public void setPersistentQueues(Boolean persistentQueues) {
     this.persistentQueues = persistentQueues;
+  }
+
+  public Boolean getLoggingCustomLog4JEnabled() {
+    return LoggingCustomLog4JEnabled;
+  }
+
+  public void setLoggingCustomLog4JEnabled(Boolean LoggingCustomLog4JEnabled) {
+    this.LoggingCustomLog4JEnabled = LoggingCustomLog4JEnabled;
   }
 
   public Integer getWaitBeforeValidation() {

--- a/mule-deployer/src/main/java/org/mule/tools/model/anypoint/CloudHubDeployment.java
+++ b/mule-deployer/src/main/java/org/mule/tools/model/anypoint/CloudHubDeployment.java
@@ -38,7 +38,7 @@ public class CloudHubDeployment extends AnypointDeployment {
   protected Boolean persistentQueues = false;
 
   @Parameter
-  protected Boolean LoggingCustomLog4JEnabled = false;
+  protected Boolean customLog4J = false;
 
   @Parameter
   protected Integer waitBeforeValidation = 6000;
@@ -111,12 +111,12 @@ public class CloudHubDeployment extends AnypointDeployment {
     this.persistentQueues = persistentQueues;
   }
 
-  public Boolean getLoggingCustomLog4JEnabled() {
-    return LoggingCustomLog4JEnabled;
+  public Boolean getCustomLog4J() {
+    return customLog4J;
   }
 
-  public void setLoggingCustomLog4JEnabled(Boolean LoggingCustomLog4JEnabled) {
-    this.LoggingCustomLog4JEnabled = LoggingCustomLog4JEnabled;
+  public void setCustomLog4J(Boolean customLog4J) {
+    this.customLog4J = customLog4J;
   }
 
   public Integer getWaitBeforeValidation() {

--- a/mule-deployer/src/test/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployerTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployerTest.java
@@ -20,6 +20,8 @@ import org.mule.tools.client.arm.model.UserInfo;
 import org.mule.tools.client.cloudhub.model.Application;
 import org.mule.tools.client.cloudhub.CloudHubClient;
 import org.mule.tools.client.cloudhub.model.Environment;
+import org.mule.tools.client.cloudhub.model.LatestUpdate;
+import org.mule.tools.client.cloudhub.model.SupportedVersion;
 import org.mule.tools.client.core.exception.DeploymentException;
 import org.mule.tools.model.anypoint.CloudHubDeployment;
 import org.mule.tools.utils.DeployerLog;
@@ -27,7 +29,9 @@ import org.mule.tools.verification.cloudhub.CloudHubDeploymentVerification;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -333,7 +337,7 @@ public class CloudHubArtifactDeployerTest {
     when(clientMock.isDomainAvailable(any())).thenReturn(true);
 
     Environment mockEnvironment = mock(Environment.class);
-    when(mockEnvironment.getObjectStoreV1Enabled()).thenReturn(true);
+    when(clientMock.getSupportedMuleVersions()).thenReturn(getObjectStoreV1Enabled(true, "4.0.0"));
 
     when(clientMock.getEnvironment()).thenReturn(mockEnvironment);
 
@@ -360,14 +364,27 @@ public class CloudHubArtifactDeployerTest {
     when(clientMock.isDomainAvailable(any())).thenReturn(true);
 
     Environment mockEnvironment = mock(Environment.class);
-    when(mockEnvironment.getObjectStoreV1Enabled()).thenReturn(false);
 
     when(clientMock.getEnvironment()).thenReturn(mockEnvironment);
+    when(clientMock.getSupportedMuleVersions()).thenReturn(getObjectStoreV1Enabled(false, "4.0.0"));
 
     cloudHubArtifactDeployer.deployApplication();
 
     ArgumentCaptor<Application> applicationCaptor = ArgumentCaptor.forClass(Application.class);
     verify(clientMock).createApplication(applicationCaptor.capture(), any());
     assertThat("ObjectStoreV1 must be true", applicationCaptor.getValue().getObjectStoreV1(), equalTo(false));
+  }
+
+  private List<SupportedVersion> getObjectStoreV1Enabled(boolean enabled, String muleVersion) {
+    List<SupportedVersion> supportedVersions = new ArrayList<SupportedVersion>();
+    SupportedVersion version = new SupportedVersion();
+    LatestUpdate update = new LatestUpdate();
+    HashMap<String, Boolean> flags = new HashMap<String, Boolean>();
+    flags.put(CloudHubArtifactDeployer.OBJECT_STOREV1, enabled);
+    update.setFlags(flags);
+    version.setLatestUpdate(update);
+    version.setVersion(muleVersion);
+    supportedVersions.add(version);
+    return supportedVersions;
   }
 }

--- a/mule-deployer/src/test/java/org/mule/tools/model/anypoint/CloudHubDeploymentTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/model/anypoint/CloudHubDeploymentTest.java
@@ -59,9 +59,9 @@ public class CloudHubDeploymentTest {
   }
 
   @Test
-  public void defaultLoggingCustomLog4JEnabledValueIsFalse() {
+  public void defaultCustomLog4JValueIsFalse() {
     assertThat("The default value for Custom Log4J property is not false",
-               deploymentSpy.getLoggingCustomLog4JEnabled(), equalTo(false));
+               deploymentSpy.getCustomLog4J(), equalTo(false));
   }
 
   @Test

--- a/mule-deployer/src/test/java/org/mule/tools/model/anypoint/CloudHubDeploymentTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/model/anypoint/CloudHubDeploymentTest.java
@@ -59,6 +59,12 @@ public class CloudHubDeploymentTest {
   }
 
   @Test
+  public void defaultLoggingCustomLog4JEnabledValueIsFalse() {
+    assertThat("The default value for Custom Log4J property is not false",
+               deploymentSpy.getLoggingCustomLog4JEnabled(), equalTo(false));
+  }
+
+  @Test
   public void defaultWaitBeforeValidationIsZero() {
     assertThat("The default value for pepe is not zero",
                deploymentSpy.getWaitBeforeValidation(), equalTo(6000));

--- a/mule-extension-model-loader/pom.xml
+++ b/mule-extension-model-loader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>mule-artifact-tools</artifactId>
         <groupId>org.mule.tools.maven</groupId>
-        <version>3.6.2-SNAPSHOT</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mule-extension-model-loader</artifactId>

--- a/mule-extension-model-loader/pom.xml
+++ b/mule-extension-model-loader/pom.xml
@@ -14,8 +14,9 @@
     <properties>
         <licensePath>../LICENSE_HEADER.txt</licensePath>
         <formatterConfigPath>../formatter.xml</formatterConfigPath>
-        <coverageLineLimit>0.61</coverageLineLimit>
-        <coverageBranchLimit>0.39</coverageBranchLimit>
+		<!-- The extension model loader is tested with integration tests mostly. It has no sense to track the coverage here -->
+        <coverageLineLimit>0</coverageLineLimit>
+        <coverageBranchLimit>0</coverageBranchLimit>
     </properties>
     <dependencies>
         <dependency>

--- a/mule-extension-model-loader/pom.xml
+++ b/mule-extension-model-loader/pom.xml
@@ -15,9 +15,13 @@
         <licensePath>../LICENSE_HEADER.txt</licensePath>
         <formatterConfigPath>../formatter.xml</formatterConfigPath>
         <coverageLineLimit>0.61</coverageLineLimit>
-        <coverageBranchLimit>0.41</coverageBranchLimit>
+        <coverageBranchLimit>0.39</coverageBranchLimit>
     </properties>
     <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+        </dependency>
         <dependency>
             <groupId> org.mule.runtime</groupId>
             <artifactId>mule-module-logging</artifactId>

--- a/mule-extension-model-loader/pom.xml
+++ b/mule-extension-model-loader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>mule-artifact-tools</artifactId>
         <groupId>org.mule.tools.maven</groupId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>3.6.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mule-extension-model-loader</artifactId>

--- a/mule-extension-model-loader/pom.xml
+++ b/mule-extension-model-loader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>mule-artifact-tools</artifactId>
         <groupId>org.mule.tools.maven</groupId>
-        <version>3.6.0-SNAPSHOT</version>
+        <version>3.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mule-extension-model-loader</artifactId>

--- a/mule-extension-model-loader/pom.xml
+++ b/mule-extension-model-loader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>mule-artifact-tools</artifactId>
         <groupId>org.mule.tools.maven</groupId>
-        <version>3.6.1-SNAPSHOT</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>mule-extension-model-loader</artifactId>

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
@@ -69,7 +69,6 @@ public class AstGenerator {
         });
       } else {
         if (artifact.getType().equals("jar")) {
-          mavenClient.resolveBundleDescriptor(toBundleDescriptor(dependency));
           try {
             classRealm.addURL(mavenClient.resolveBundleDescriptor(toBundleDescriptor(dependency)).getBundleUri().toURL());
           } catch (MalformedURLException e1) {

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
@@ -71,7 +71,8 @@ public class AstGenerator {
         if (artifact.getType().equals("jar")) {
           try {
             classRealm.addURL(mavenClient.resolveBundleDescriptor(toBundleDescriptor(dependency)).getBundleUri().toURL());
-          } catch (MalformedURLException e1) {
+            // this seldom can throw ArtifactResolutionException and we should not stop the build for that
+          } catch (Exception e1) {
             e1.printStackTrace();
           }
         }

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/api/ExtensionModelLoader.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/api/ExtensionModelLoader.java
@@ -2,8 +2,7 @@ package org.mule.tooling.api;
 
 import org.mule.maven.client.api.model.BundleDescriptor;
 import org.mule.runtime.api.meta.model.ExtensionModel;
-import org.mule.runtime.api.util.Pair;
-import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
+import org.mule.tooling.internal.PluginResources;
 
 import java.util.Set;
 
@@ -11,7 +10,7 @@ public interface ExtensionModelLoader {
 
   Set<ExtensionModel> getRuntimeExtensionModels();
 
-  Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> load(BundleDescriptor artifactDescriptor);
+  PluginResources load(BundleDescriptor artifactDescriptor);
 
 
 }

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/api/ExtensionModelService.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/api/ExtensionModelService.java
@@ -3,21 +3,19 @@ package org.mule.tooling.api;
 import org.mule.maven.client.api.model.BundleDescriptor;
 import org.mule.runtime.api.meta.MuleVersion;
 import org.mule.runtime.api.meta.model.ExtensionModel;
-import org.mule.runtime.api.util.Pair;
-import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
+import org.mule.tooling.internal.PluginResources;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 public interface ExtensionModelService {
 
   List<ExtensionModel> loadRuntimeExtensionModels();
 
-  Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> loadExtensionData(File pluginJarFile);
+  PluginResources loadExtensionData(File pluginJarFile);
 
   BundleDescriptor readBundleDescriptor(File pluginFile);
 
-  Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> loadExtensionData(BundleDescriptor pluginDescriptor,
+  PluginResources loadExtensionData(BundleDescriptor pluginDescriptor,
                                                                         MuleVersion muleVersion);
 }

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/DefaultExtensionModelLoader.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/DefaultExtensionModelLoader.java
@@ -13,7 +13,6 @@ import org.mule.runtime.container.internal.JreModuleDiscoverer;
 import org.mule.runtime.container.internal.ModuleDiscoverer;
 import org.mule.runtime.core.api.extension.MuleExtensionModelProvider;
 import org.mule.runtime.deployment.model.api.artifact.extension.ExtensionModelDiscoverer;
-import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
 import org.mule.runtime.extension.api.extension.XmlSdk1ExtensionModelProvider;
 import org.mule.runtime.module.artifact.api.classloader.ArtifactClassLoader;
 import org.mule.tooling.api.ExtensionModelLoader;
@@ -24,8 +23,6 @@ import com.mulesoft.mule.runtime.http.policy.api.extension.HttpPolicyEeExtension
 import com.mulesoft.mule.runtime.module.batch.api.extension.BatchExtensionModelProvider;
 import com.mulesoft.mule.runtime.module.serialization.kryo.api.extension.KryoSerializerEeExtensionModelProvider;
 import com.mulesoft.mule.runtime.tracking.api.extension.TrackingEeExtensionModelProvider;
-
-import org.mule.runtime.api.util.Pair;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -75,7 +72,7 @@ public class DefaultExtensionModelLoader implements ExtensionModelLoader {
   }
 
   @Override
-  public Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> load(BundleDescriptor artifactDescriptor) {
+  public PluginResources load(BundleDescriptor artifactDescriptor) {
     return service.loadExtensionData(artifactDescriptor, muleVersion);
   }
 }

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/DefaultExtensionModelService.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/DefaultExtensionModelService.java
@@ -223,7 +223,7 @@ public class DefaultExtensionModelService implements ExtensionModelService {
 
   @Override
   public PluginResources loadExtensionData(BundleDescriptor pluginDescriptor,
-                                                                               MuleVersion muleVersion) {
+                                           MuleVersion muleVersion) {
     long startTime = nanoTime();
     PluginResources extensionInformationOptional =
         withTemporaryApplication(pluginDescriptor, emptyMap(),
@@ -241,9 +241,9 @@ public class DefaultExtensionModelService implements ExtensionModelService {
   }
 
   private PluginResources withTemporaryApplication(BundleDescriptor pluginDescriptor,
-                                                                                       Map<String, Object> classLoaderModelLoaderAttributes,
-                                                                                       TemporaryApplicationFunction action,
-                                                                                       MuleVersion muleVersion) {
+                                                   Map<String, Object> classLoaderModelLoaderAttributes,
+                                                   TemporaryApplicationFunction action,
+                                                   MuleVersion muleVersion) {
     String uuid = getUUID();
     String applicationName = uuid + "-extension-model-temp-app";
     File applicationFolder = new File(muleArtifactResourcesRegistry.getWorkingDirectory(), applicationName);
@@ -326,23 +326,29 @@ public class DefaultExtensionModelService implements ExtensionModelService {
   interface TemporaryApplicationFunction {
 
     PluginResources call(ArtifactPluginDescriptor artifactPluginDescriptor,
-                                                             ToolingArtifactClassLoader toolingArtifactClassLoader,
-                                                             Map<String, String> properties);
+                         ToolingArtifactClassLoader toolingArtifactClassLoader,
+                         Map<String, String> properties);
   }
 
   private DeployableArtifactClassLoaderFactory<ApplicationDescriptor> newTemporaryArtifactClassLoaderFactory() {
-    return (artifactId, parent, descriptor, artifactPluginClassLoaders) -> new MuleDeployableArtifactClassLoader(artifactId, descriptor, descriptor.getClassLoaderModel().getUrls(),
-                                                 parent.getClassLoader(),
-                                                 parent.getClassLoaderLookupPolicy(), artifactPluginClassLoaders);
+    return (artifactId, parent, descriptor,
+            artifactPluginClassLoaders) -> new MuleDeployableArtifactClassLoader(artifactId, descriptor,
+                                                                                 descriptor.getClassLoaderModel().getUrls(),
+                                                                                 parent.getClassLoader(),
+                                                                                 parent.getClassLoaderLookupPolicy(),
+                                                                                 artifactPluginClassLoaders);
   }
 
   private PluginResources loadExtensionData(ArtifactPluginDescriptor artifactPluginDescriptor,
-                                                                                ToolingArtifactClassLoader toolingArtifactClassLoader,
-                                                                                Map<String, String> properties) {
+                                            ToolingArtifactClassLoader toolingArtifactClassLoader,
+                                            Map<String, String> properties) {
     try {
       ArrayList<URL> resources = new ArrayList<URL>();
-      artifactPluginDescriptor.getClassLoaderModel().getExportedResources().forEach(resource->
-      resources.add(toolingArtifactClassLoader.getRegionClassLoader().getResource(resource)));
+      artifactPluginDescriptor.getClassLoaderModel().getExportedResources().forEach(resource -> {
+        if (toolingArtifactClassLoader.getRegionClassLoader().getResource(resource) != null) {
+          resources.add(toolingArtifactClassLoader.getRegionClassLoader().getResource(resource));
+        }
+      });
       MuleExtensionModelLoaderManager extensionModelLoaderRepository =
           new MuleExtensionModelLoaderManager(muleArtifactResourcesRegistry.getContainerArtifactClassLoader());
       extensionModelLoaderRepository.start();

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/DefaultExtensionModelService.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/DefaultExtensionModelService.java
@@ -50,6 +50,7 @@ import org.mule.tooling.api.ToolingException;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -97,7 +98,7 @@ public class DefaultExtensionModelService implements ExtensionModelService {
   }
 
   @Override
-  public Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> loadExtensionData(File pluginJarFile) {
+  public PluginResources loadExtensionData(File pluginJarFile) {
     long startTime = nanoTime();
     org.mule.runtime.module.artifact.api.descriptor.BundleDescriptor bundleDescriptor =
         readArtifactPluginDescriptor(pluginJarFile).getBundleDescriptor();
@@ -114,7 +115,7 @@ public class DefaultExtensionModelService implements ExtensionModelService {
         .setVersion(bundleDescriptor.getVersion())
         .setClassifier(bundleDescriptor.getClassifier().orElse(null))
         .build();
-    Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> extensionInformationOptional =
+    PluginResources extensionInformationOptional =
         withTemporaryApplication(pluginDescriptor, classLoaderModelAttributes,
                                  (artifactPluginDescriptor,
                                   toolingArtifactClassLoader,
@@ -221,10 +222,10 @@ public class DefaultExtensionModelService implements ExtensionModelService {
 
 
   @Override
-  public Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> loadExtensionData(BundleDescriptor pluginDescriptor,
+  public PluginResources loadExtensionData(BundleDescriptor pluginDescriptor,
                                                                                MuleVersion muleVersion) {
     long startTime = nanoTime();
-    Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> extensionInformationOptional =
+    PluginResources extensionInformationOptional =
         withTemporaryApplication(pluginDescriptor, emptyMap(),
                                  (artifactPluginDescriptor,
                                   toolingArtifactClassLoader,
@@ -239,7 +240,7 @@ public class DefaultExtensionModelService implements ExtensionModelService {
     return extensionInformationOptional;
   }
 
-  private Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> withTemporaryApplication(BundleDescriptor pluginDescriptor,
+  private PluginResources withTemporaryApplication(BundleDescriptor pluginDescriptor,
                                                                                        Map<String, Object> classLoaderModelLoaderAttributes,
                                                                                        TemporaryApplicationFunction action,
                                                                                        MuleVersion muleVersion) {
@@ -324,7 +325,7 @@ public class DefaultExtensionModelService implements ExtensionModelService {
   @FunctionalInterface
   interface TemporaryApplicationFunction {
 
-    Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> call(ArtifactPluginDescriptor artifactPluginDescriptor,
+    PluginResources call(ArtifactPluginDescriptor artifactPluginDescriptor,
                                                              ToolingArtifactClassLoader toolingArtifactClassLoader,
                                                              Map<String, String> properties);
   }
@@ -335,16 +336,19 @@ public class DefaultExtensionModelService implements ExtensionModelService {
                                                  parent.getClassLoaderLookupPolicy(), artifactPluginClassLoaders);
   }
 
-  private Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> loadExtensionData(ArtifactPluginDescriptor artifactPluginDescriptor,
+  private PluginResources loadExtensionData(ArtifactPluginDescriptor artifactPluginDescriptor,
                                                                                 ToolingArtifactClassLoader toolingArtifactClassLoader,
                                                                                 Map<String, String> properties) {
     try {
+      ArrayList<URL> resources = new ArrayList<URL>();
+      artifactPluginDescriptor.getClassLoaderModel().getExportedResources().forEach(resource->
+      resources.add(toolingArtifactClassLoader.getRegionClassLoader().getResource(resource)));
       MuleExtensionModelLoaderManager extensionModelLoaderRepository =
           new MuleExtensionModelLoaderManager(muleArtifactResourcesRegistry.getContainerArtifactClassLoader());
       extensionModelLoaderRepository.start();
       final Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> loadedExtensionInformation =
           discoverPluginsExtensionModel(toolingArtifactClassLoader, extensionModelLoaderRepository, properties);
-      return loadedExtensionInformation;
+      return new PluginResources(loadedExtensionInformation, resources);
     } catch (Exception e) {
       throw new ToolingException(e);
     } finally {

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/PluginResources.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/PluginResources.java
@@ -1,0 +1,30 @@
+package org.mule.tooling.internal;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Set;
+
+import org.mule.runtime.api.meta.model.ExtensionModel;
+import org.mule.runtime.api.util.Pair;
+import org.mule.runtime.deployment.model.api.plugin.ArtifactPluginDescriptor;
+
+public class PluginResources {
+
+  private Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> extensionModels;
+  private List<URL> exportedResources;
+
+  public PluginResources(Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> extensionModels, List<URL> exportedResources) {
+    super();
+    this.extensionModels = extensionModels;
+    this.exportedResources = exportedResources;
+  }
+
+  public List<URL> getExportedResources() {
+    return exportedResources;
+  }
+
+
+  public Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> getExtensionModels() {
+    return extensionModels;
+  }
+}

--- a/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/AstGeneratorTest.java
+++ b/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/AstGeneratorTest.java
@@ -53,7 +53,7 @@ public class AstGeneratorTest extends MavenClientTest {
     AstGenerator generator = new AstGenerator(client, "4.3.0", dependencies, workingPath, null);
     Path configsBasePath = workingPath.resolve("src/main/mule");
     ArtifactAst artifact =
-        generator.generateAST(Arrays.asList("/" + configsBasePath.resolve("mule-config.xml").toFile().getAbsolutePath()),
+        generator.generateAST(Arrays.asList(configsBasePath.resolve("mule-config.xml").toFile().getAbsolutePath()),
                               configsBasePath);
     generator.validateAST(artifact);
     String absolutePath = workingPath.toFile().getAbsolutePath();
@@ -73,7 +73,7 @@ public class AstGeneratorTest extends MavenClientTest {
     AstGenerator generator = new AstGenerator(client, "4.3.0", dependencies, workingPath, null);
     Path configsBasePath = workingPath.resolve("src/main/mule");
     ArtifactAst artifact =
-        generator.generateAST(Arrays.asList("/" + configsBasePath.resolve("mule-config2.xml").toFile().getAbsolutePath()),
+        generator.generateAST(Arrays.asList(configsBasePath.resolve("mule-config2.xml").toFile().getAbsolutePath()),
                               configsBasePath);
     generator.validateAST(artifact);
   }

--- a/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/AstGeneratorTest.java
+++ b/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/AstGeneratorTest.java
@@ -16,10 +16,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.nio.file.Paths;
-
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
 import org.junit.Test;
 import org.mule.maven.client.api.MavenClient;
@@ -47,7 +49,7 @@ public class AstGeneratorTest extends MavenClientTest {
                                                 getMavenConfiguration(m2Repo, Optional.ofNullable(getUserSettings(m2Repo)),
                                                                       Optional.ofNullable(getSettingsSecurity(m2Repo))));
     Path workingPath = Paths.get("src", "test", "resources", "test-project");
-    List<Dependency> dependencies = new ArrayList<Dependency>();
+    Set<Artifact> dependencies = new HashSet<Artifact>();
     AstGenerator generator = new AstGenerator(client, "4.3.0", dependencies, workingPath, null);
     Path configsBasePath = workingPath.resolve("src/main/mule");
     ArtifactAst artifact =
@@ -67,7 +69,7 @@ public class AstGeneratorTest extends MavenClientTest {
                                                 getMavenConfiguration(m2Repo, Optional.ofNullable(getUserSettings(m2Repo)),
                                                                       Optional.ofNullable(getSettingsSecurity(m2Repo))));
     Path workingPath = Paths.get("src", "test", "resources", "test-project");
-    List<Dependency> dependencies = new ArrayList<Dependency>();
+    Set<Artifact> dependencies = new HashSet<Artifact>();
     AstGenerator generator = new AstGenerator(client, "4.3.0", dependencies, workingPath, null);
     Path configsBasePath = workingPath.resolve("src/main/mule");
     ArtifactAst artifact =

--- a/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/AstGeneratorTest.java
+++ b/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/AstGeneratorTest.java
@@ -48,7 +48,7 @@ public class AstGeneratorTest extends MavenClientTest {
                                                                       Optional.ofNullable(getSettingsSecurity(m2Repo))));
     Path workingPath = Paths.get("src", "test", "resources", "test-project");
     List<Dependency> dependencies = new ArrayList<Dependency>();
-    AstGenerator generator = new AstGenerator(client, "4.3.0", dependencies, workingPath);
+    AstGenerator generator = new AstGenerator(client, "4.3.0", dependencies, workingPath, null);
     Path configsBasePath = workingPath.resolve("src/main/mule");
     ArtifactAst artifact =
         generator.generateAST(Arrays.asList("/" + configsBasePath.resolve("mule-config.xml").toFile().getAbsolutePath()),
@@ -68,7 +68,7 @@ public class AstGeneratorTest extends MavenClientTest {
                                                                       Optional.ofNullable(getSettingsSecurity(m2Repo))));
     Path workingPath = Paths.get("src", "test", "resources", "test-project");
     List<Dependency> dependencies = new ArrayList<Dependency>();
-    AstGenerator generator = new AstGenerator(client, "4.3.0", dependencies, workingPath);
+    AstGenerator generator = new AstGenerator(client, "4.3.0", dependencies, workingPath, null);
     Path configsBasePath = workingPath.resolve("src/main/mule");
     ArtifactAst artifact =
         generator.generateAST(Arrays.asList("/" + configsBasePath.resolve("mule-config2.xml").toFile().getAbsolutePath()),

--- a/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/ExtensionModelLoaderTest.java
+++ b/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/ExtensionModelLoaderTest.java
@@ -51,7 +51,7 @@ public class ExtensionModelLoaderTest extends MavenClientTest {
     ExtensionModelLoader extensionModelLoader =
         ExtensionModelLoaderFactory.createLoader(client, temp, ModuleDiscoverer.class.getClassLoader(), "4.4.0");
 
-    Set<Pair<ArtifactPluginDescriptor, ExtensionModel>> http = extensionModelLoader.load(
+    PluginResources http = extensionModelLoader.load(
                                                                                 new BundleDescriptor.Builder()
                                                                                     .setGroupId("org.mule.connectors")
                                                                                     .setArtifactId("mule-http-connector")
@@ -59,7 +59,7 @@ public class ExtensionModelLoaderTest extends MavenClientTest {
                                                                                     .setVersion("1.5.25").build());
     assertEquals("Loaded a different amount of runtime extension models than expected", 10,
             extensionModelLoader.getRuntimeExtensionModels().size());
-    assertEquals("Loaded a different amount of plugin extension models than expected",2,http.size());
+    assertEquals("Loaded a different amount of plugin extension models than expected",2,http.getExtensionModels().size());
 
   }
 

--- a/mule-maven-plugin/pom.xml
+++ b/mule-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.1-SNAPSHOT</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-maven-plugin/pom.xml
+++ b/mule-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>3.6.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-maven-plugin/pom.xml
+++ b/mule-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.0-SNAPSHOT</version>
+        <version>3.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-maven-plugin/pom.xml
+++ b/mule-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.2-SNAPSHOT</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -37,6 +39,9 @@ import org.mule.tooling.api.ConfigurationException;
     defaultPhase = LifecyclePhase.COMPILE,
     requiresDependencyResolution = ResolutionScope.RUNTIME)
 public class CompileMojo extends AbstractMuleMojo {
+
+  @Component
+  private PluginDescriptor descriptor;
 
 
   private static final String RUNTIME_AST_VERSION = "4.4.0";
@@ -86,7 +91,8 @@ public class CompileMojo extends AbstractMuleMojo {
   public ArtifactAst getArtifactAst() throws IOException, ConfigurationException {
 
     AstGenerator astGenerator = new AstGenerator(getAetherMavenClient(), RUNTIME_AST_VERSION,
-                                                 project.getDependencies(), Paths.get(project.getBuild().getDirectory()));
+                                                 project.getDependencies(), Paths.get(project.getBuild().getDirectory()),
+                                                 descriptor.getClassRealm());
     ProjectStructure projectStructure = new ProjectStructure(projectBaseFolder.toPath(), false);
     MuleArtifactContentResolver contentResolver =
         new MuleArtifactContentResolver(new ProjectStructure(projectBaseFolder.toPath(), false),

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
@@ -12,25 +12,15 @@ package org.mule.tools.maven.mojo;
 
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Paths;
-import java.util.ArrayList;
 
-import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.mule.runtime.ast.api.ArtifactAst;
-import org.mule.runtime.ast.api.validation.ValidationResultItem;
-import org.mule.tools.api.packager.sources.MuleArtifactContentResolver;
 import org.mule.tools.api.packager.sources.MuleContentGenerator;
-import org.mule.tools.api.packager.structure.ProjectStructure;
-import org.mule.tooling.api.AstGenerator;
-import org.mule.tooling.api.ConfigurationException;
-import static org.mule.tools.api.packager.packaging.Classifier.MULE_PLUGIN;
+
 
 /**
  * @author Mulesoft Inc.
@@ -44,73 +34,18 @@ public class CompileMojo extends AbstractMuleMojo {
   @Component
   private PluginDescriptor descriptor;
 
-
-  private static final String RUNTIME_AST_VERSION = "4.4.0";
-  private static final String MULE_POLICY = "mule-policy";
-  private static final String MULE_DOMAIN = "mule-domain";
-  private static final String SKIP_AST = "skipAST";
-  private static final String SKIP_AST_VALIDATION = "skipASTValidation";
-
   @Override
   public void doExecute() throws MojoFailureException {
     getLog().debug("Generating mule source code...");
     try {
       ((MuleContentGenerator) getContentGenerator()).createMuleSrcFolderContent();
-      String skipAST = System.getProperty(SKIP_AST);
-      // apps in domains are not currently supported MMP-588
-      if ((skipAST == null || skipAST.equals("false")) && !project.getPackaging().equals(MULE_POLICY) && !hasDomain()) {
-        ArtifactAst artifact = getArtifactAst();
-        if (artifact != null) {
-          ((MuleContentGenerator) getContentGenerator()).createAstFile(serialize(artifact));
-        }
-      }
-    } catch (IllegalArgumentException | IOException | ConfigurationException e) {
+    } catch (IllegalArgumentException | IOException e) {
       throw new MojoFailureException("Fail to compile", e);
     }
-  }
-
-
-  private boolean hasDomain() {
-    if (project.getDependencies() != null) {
-      for (Dependency dependency : project.getDependencies()) {
-        if (dependency.getClassifier() != null && dependency.getClassifier().equals(MULE_DOMAIN)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  public InputStream serialize(ArtifactAst artifact) {
-    return AstGenerator.serialize(artifact);
   }
 
   @Override
   public String getPreviousRunPlaceholder() {
     return "MULE_MAVEN_PLUGIN_COMPILE_PREVIOUS_RUN_PLACEHOLDER";
-  }
-
-  public ArtifactAst getArtifactAst() throws IOException, ConfigurationException {
-    descriptor.getClassRealm()
-        .addURL(project.getBasedir().toPath().resolve("src").resolve("main").resolve("resources").toUri().toURL());
-    AstGenerator astGenerator = new AstGenerator(getAetherMavenClient(), RUNTIME_AST_VERSION,
-                                                 project.getArtifacts(), Paths.get(project.getBuild().getDirectory()),
-                                                 descriptor.getClassRealm());
-    ProjectStructure projectStructure = new ProjectStructure(projectBaseFolder.toPath(), false);
-    MuleArtifactContentResolver contentResolver =
-        new MuleArtifactContentResolver(new ProjectStructure(projectBaseFolder.toPath(), false),
-                                        getProjectInformation().getEffectivePom(),
-                                        getProjectInformation().getProject().getBundleDependencies());
-
-    ArtifactAst artifactAST = astGenerator.generateAST(contentResolver.getConfigs(), projectStructure.getConfigsPath());
-    String skipASTValidation = System.getProperty(SKIP_AST_VALIDATION);
-    if (artifactAST != null && !this.getClassifier().equalsIgnoreCase(MULE_PLUGIN.toString())
-        && (skipASTValidation == null || skipASTValidation.equals("false"))) {
-      ArrayList<ValidationResultItem> warnings = astGenerator.validateAST(artifactAST);
-      for (ValidationResultItem warning : warnings) {
-        getLog().warn(warning.getMessage());
-      }
-    }
-    return artifactAST;
   }
 }

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
@@ -30,6 +30,7 @@ import org.mule.tools.api.packager.sources.MuleContentGenerator;
 import org.mule.tools.api.packager.structure.ProjectStructure;
 import org.mule.tooling.api.AstGenerator;
 import org.mule.tooling.api.ConfigurationException;
+import static org.mule.tools.api.packager.packaging.Classifier.MULE_PLUGIN;
 
 /**
  * @author Mulesoft Inc.
@@ -104,7 +105,8 @@ public class CompileMojo extends AbstractMuleMojo {
 
     ArtifactAst artifactAST = astGenerator.generateAST(contentResolver.getConfigs(), projectStructure.getConfigsPath());
     String skipASTValidation = System.getProperty(SKIP_AST_VALIDATION);
-    if (artifactAST != null && (skipASTValidation == null || skipASTValidation.equals("false"))) {
+    if (artifactAST != null && !this.getClassifier().equalsIgnoreCase(MULE_PLUGIN.toString())
+        && (skipASTValidation == null || skipASTValidation.equals("false"))) {
       ArrayList<ValidationResultItem> warnings = astGenerator.validateAST(artifactAST);
       for (ValidationResultItem warning : warnings) {
         getLog().warn(warning.getMessage());

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
@@ -48,6 +48,7 @@ public class CompileMojo extends AbstractMuleMojo {
   private static final String MULE_POLICY = "mule-policy";
   private static final String MULE_DOMAIN = "mule-domain";
   private static final String SKIP_AST = "skipAST";
+  private static final String SKIP_AST_VALIDATION = "skipASTValidation";
 
   @Override
   public void doExecute() throws MojoFailureException {
@@ -90,6 +91,8 @@ public class CompileMojo extends AbstractMuleMojo {
 
   public ArtifactAst getArtifactAst() throws IOException, ConfigurationException {
 
+    descriptor.getClassRealm()
+        .addURL(project.getBasedir().toPath().resolve("src").resolve("main").resolve("resources").toUri().toURL());
     AstGenerator astGenerator = new AstGenerator(getAetherMavenClient(), RUNTIME_AST_VERSION,
                                                  project.getDependencies(), Paths.get(project.getBuild().getDirectory()),
                                                  descriptor.getClassRealm());
@@ -100,7 +103,8 @@ public class CompileMojo extends AbstractMuleMojo {
                                         getProjectInformation().getProject().getBundleDependencies());
 
     ArtifactAst artifactAST = astGenerator.generateAST(contentResolver.getConfigs(), projectStructure.getConfigsPath());
-    if (artifactAST != null) {
+    String skipASTValidation = System.getProperty(SKIP_AST_VALIDATION);
+    if (artifactAST != null && (skipASTValidation == null || skipASTValidation.equals("false"))) {
       ArrayList<ValidationResultItem> warnings = astGenerator.validateAST(artifactAST);
       for (ValidationResultItem warning : warnings) {
         getLog().warn(warning.getMessage());

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/CompileMojo.java
@@ -91,11 +91,10 @@ public class CompileMojo extends AbstractMuleMojo {
   }
 
   public ArtifactAst getArtifactAst() throws IOException, ConfigurationException {
-
     descriptor.getClassRealm()
         .addURL(project.getBasedir().toPath().resolve("src").resolve("main").resolve("resources").toUri().toURL());
     AstGenerator astGenerator = new AstGenerator(getAetherMavenClient(), RUNTIME_AST_VERSION,
-                                                 project.getDependencies(), Paths.get(project.getBuild().getDirectory()),
+                                                 project.getArtifacts(), Paths.get(project.getBuild().getDirectory()),
                                                  descriptor.getClassRealm());
     ProjectStructure projectStructure = new ProjectStructure(projectBaseFolder.toPath(), false);
     MuleArtifactContentResolver contentResolver =

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/ProcessClassesMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/ProcessClassesMojo.java
@@ -10,12 +10,31 @@
 
 package org.mule.tools.maven.mojo;
 
+import static org.mule.tools.api.packager.packaging.Classifier.MULE_PLUGIN;
 import static org.mule.tools.maven.mojo.model.lifecycle.MavenLifecyclePhase.VALIDATE;
+
+import org.mule.runtime.ast.api.ArtifactAst;
+import org.mule.runtime.ast.api.validation.ValidationResultItem;
+import org.mule.tooling.api.AstGenerator;
+import org.mule.tooling.api.ConfigurationException;
 import org.mule.tools.api.exception.ValidationException;
+import org.mule.tools.api.packager.sources.MuleArtifactContentResolver;
+import org.mule.tools.api.packager.sources.MuleContentGenerator;
+import org.mule.tools.api.packager.structure.ProjectStructure;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -30,9 +49,30 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
     requiresDependencyResolution = ResolutionScope.TEST)
 public class ProcessClassesMojo extends AbstractMuleMojo {
 
+  @Component
+  private PluginDescriptor descriptor;
+  private static final String RUNTIME_AST_VERSION = "4.4.0";
+  private static final String MULE_POLICY = "mule-policy";
+  private static final String MULE_DOMAIN = "mule-domain";
+  private static final String SKIP_AST = "skipAST";
+  private static final String SKIP_AST_VALIDATION = "skipASTValidation";
+
   @Override
-  public void doExecute() throws MojoExecutionException {
+  public void doExecute() throws MojoExecutionException, MojoFailureException {
     getLog().debug("Generating process-classes code...");
+    try {
+
+      String skipAST = System.getProperty(SKIP_AST);
+      // apps in domains are not currently supported MMP-588
+      if ((skipAST == null || skipAST.equals("false")) && !project.getPackaging().equals(MULE_POLICY) && !hasDomain()) {
+        ArtifactAst artifact = getArtifactAst();
+        if (artifact != null) {
+          ((MuleContentGenerator) getContentGenerator()).createAstFile(serialize(artifact));
+        }
+      }
+    } catch (IllegalArgumentException | IOException | ConfigurationException e) {
+      throw new MojoFailureException("Fail to compile", e);
+    }
     try {
       getContentGenerator().copyDescriptorFile();
       if (!skipValidation) {
@@ -49,6 +89,45 @@ public class ProcessClassesMojo extends AbstractMuleMojo {
   @Override
   public String getPreviousRunPlaceholder() {
     return "MULE_MAVEN_PLUGIN_PROCESS_CLASSES_PREVIOUS_RUN_PLACEHOLDER";
+  }
+
+  public ArtifactAst getArtifactAst() throws IOException, ConfigurationException {
+    descriptor.getClassRealm()
+        .addURL(project.getBasedir().toPath().resolve("src").resolve("main").resolve("resources").toUri().toURL());
+    AstGenerator astGenerator = new AstGenerator(getAetherMavenClient(), RUNTIME_AST_VERSION,
+                                                 project.getArtifacts(), Paths.get(project.getBuild().getDirectory()),
+                                                 descriptor.getClassRealm());
+    ProjectStructure projectStructure = new ProjectStructure(projectBaseFolder.toPath(), false);
+    MuleArtifactContentResolver contentResolver =
+        new MuleArtifactContentResolver(new ProjectStructure(projectBaseFolder.toPath(), false),
+                                        getProjectInformation().getEffectivePom(),
+                                        getProjectInformation().getProject().getBundleDependencies());
+
+    ArtifactAst artifactAST = astGenerator.generateAST(contentResolver.getConfigs(), projectStructure.getConfigsPath());
+    String skipASTValidation = System.getProperty(SKIP_AST_VALIDATION);
+    if (artifactAST != null && !this.getClassifier().equalsIgnoreCase(MULE_PLUGIN.toString())
+        && (skipASTValidation == null || skipASTValidation.equals("false"))) {
+      ArrayList<ValidationResultItem> warnings = astGenerator.validateAST(artifactAST);
+      for (ValidationResultItem warning : warnings) {
+        getLog().warn(warning.getMessage());
+      }
+    }
+    return artifactAST;
+  }
+
+  private boolean hasDomain() {
+    if (project.getDependencies() != null) {
+      for (Dependency dependency : project.getDependencies()) {
+        if (dependency.getClassifier() != null && dependency.getClassifier().equals(MULE_DOMAIN)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  public InputStream serialize(ArtifactAst artifact) {
+    return AstGenerator.serialize(artifact);
   }
 
 }

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/MuleLifecycleMapping.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/MuleLifecycleMapping.java
@@ -55,7 +55,7 @@ public class MuleLifecycleMapping implements LifecycleMapping, ProjectLifecycleM
   private static final String MAVEN_INSTALL_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-install-plugin:2.5.2";
   private static final String MAVEN_DEPLOY_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-deploy-plugin:2.8.2";
   private static final String MAVEN_SITE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-site-plugin:3.8.2";
-  private static final String EXCHANGE_PUBLICATION_PLUGIN = EXCHANGE_PLUGIN + ":exchange-mule-maven-plugin:0.0.16";
+  private static final String EXCHANGE_PUBLICATION_PLUGIN = EXCHANGE_PLUGIN + ":exchange-mule-maven-plugin:0.0.17";
 
   @Override
   public List<String> getOptionalMojos(String lifecycle) {

--- a/mule-maven-plugin/src/test/java/org/mule/tools/maven/mojo/CompileMojoTest.java
+++ b/mule-maven-plugin/src/test/java/org/mule/tools/maven/mojo/CompileMojoTest.java
@@ -19,11 +19,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.StringInputStream;
 import org.junit.Before;
 import org.junit.Test;
-import org.mule.runtime.ast.api.ArtifactAst;
-import org.mule.tooling.api.AstGenerator;
 import org.mule.tooling.api.ConfigurationException;
 import org.mule.tools.api.packager.sources.MuleContentGenerator;
 
@@ -54,18 +51,13 @@ public class CompileMojoTest extends AbstractMuleMojoTest {
   public void execute()
       throws FileNotFoundException, ConfigurationException, IOException, MojoExecutionException, MojoFailureException {
     MuleContentGenerator contentGeneratorMock = mock(MuleContentGenerator.class);
-    InputStream stream = new StringInputStream("");
     doReturn(contentGeneratorMock).when(mojoMock).getContentGenerator();
-    ArtifactAst artifactAst = mock(ArtifactAst.class);
-    doReturn(artifactAst).when(mojoMock).getArtifactAst();
-    doReturn(stream).when(mojoMock).serialize(artifactAst);
     doCallRealMethod().when(mojoMock).execute();
     doCallRealMethod().when(mojoMock).doExecute();
     mojoMock.execute();
 
-    verify(mojoMock, times(2)).getContentGenerator();
+    verify(mojoMock, times(1)).getContentGenerator();
     verify(contentGeneratorMock, times(1)).createMuleSrcFolderContent();
-    verify(contentGeneratorMock, times(1)).createAstFile(stream);
   }
 
   @Test(expected = MojoFailureException.class)

--- a/mule-packager/pom.xml
+++ b/mule-packager/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.1-SNAPSHOT</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-packager/pom.xml
+++ b/mule-packager/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>3.6.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-packager/pom.xml
+++ b/mule-packager/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.0-SNAPSHOT</version>
+        <version>3.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/mule-packager/pom.xml
+++ b/mule-packager/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.mule.tools.maven</groupId>
         <artifactId>mule-artifact-tools</artifactId>
-        <version>3.6.2-SNAPSHOT</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-artifact-tools</artifactId>
-    <version>3.6.1-SNAPSHOT</version>
+    <version>3.6.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Mule Artifact Tools</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-artifact-tools</artifactId>
-    <version>3.6.0-SNAPSHOT</version>
+    <version>3.6.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Mule Artifact Tools</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-artifact-tools</artifactId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>3.6.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Mule Artifact Tools</name>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven.dependency.plugin.version>2.10</maven.dependency.plugin.version>
         <maven.plugin.annotations.version>3.6.0</maven.plugin.annotations.version>
-        <exchange.plugin.version>0.0.16</exchange.plugin.version>
+        <exchange.plugin.version>0.0.17</exchange.plugin.version>
 
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <maven.resources.plugin.version>2.7</maven.resources.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-artifact-tools</artifactId>
-    <version>3.6.2-SNAPSHOT</version>
+    <version>3.6.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Mule Artifact Tools</name>


### PR DESCRIPTION
Based on this [entry](https://help.mulesoft.com/s/ideas#08734000000HV2fAAG) from the ideas portal.
The idea is to add a way to handle the _loggingCustomLog4JEnabled_ property when deploying an application to CloudHub, which, at the moment, can only be done by following [this article](https://help.mulesoft.com/s/article/How-to-disable-CloudHub-logging-using-API)