### PR TITLE
Cherrypick W-11327063

### DIFF
--- a/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/InstallMojoTest.java
+++ b/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/InstallMojoTest.java
@@ -35,6 +35,9 @@ public class InstallMojoTest extends MojoTest {
   private static final String MULE_APPLICATION_TEMPLATE_CLASSIFIER = "mule-application-template";
   private static final String MULE_APPLICATION_CLASSIFIER_LIGHT_PACKAGE = "mule-application-light-package";
   private static final String MULE_APPLICATION_WITH_PLUGIN_DEP = "simple-app-with-lib";
+  private static final String MULE_PARENT = "test-parent-pom";
+  private static final String MULE_CHILD = "test-child";
+  private static final String MULE_RELATIVE_PATH = "test-relative-path";
   private static final String MULE_PLUGIN = "simple-lib";
   private static final String INCOMPLETE_PLUGIN = "incomplete-mule-plugin";
 
@@ -241,6 +244,29 @@ public class InstallMojoTest extends MojoTest {
     verifierPlugin.deleteArtifacts(GROUP_ID, MULE_PLUGIN, VERSION);
 
     verifierPlugin.executeGoal(INSTALL);
+    verifier.executeGoal(INSTALL);
+    verifier.verifyErrorFreeLog();
+  }
+
+  @Test
+  public void testInstallAppWithParentWithRelativePath() throws IOException, VerificationException {
+    File parentBaseDirectory = builder.createProjectBaseDir(MULE_PARENT, this.getClass());
+    File libWithRelativeParentBaseDirectory = builder.createProjectBaseDir(MULE_CHILD, this.getClass());
+    projectBaseDirectory = builder.createProjectBaseDir(MULE_RELATIVE_PATH, this.getClass());
+
+
+
+    Verifier verifierParent = buildVerifier(parentBaseDirectory);
+    Verifier verifierChild = buildVerifier(libWithRelativeParentBaseDirectory);
+    verifier = buildVerifier(projectBaseDirectory);
+
+    verifierParent.deleteArtifacts(GROUP_ID, MULE_PARENT, VERSION);
+    verifierChild.deleteArtifacts(GROUP_ID, MULE_CHILD, VERSION);
+    verifier.deleteArtifacts(GROUP_ID, MULE_RELATIVE_PATH, VERSION);
+
+
+    verifierParent.executeGoal(INSTALL);
+    verifierChild.executeGoal(INSTALL);
     verifier.executeGoal(INSTALL);
     verifier.verifyErrorFreeLog();
   }

--- a/mule-artifact-it/mule-packager-it/src/test/resources/test-child/mule-artifact.json
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/test-child/mule-artifact.json
@@ -1,0 +1,3 @@
+{
+  "minMuleVersion": "4.3.0"
+}

--- a/mule-artifact-it/mule-packager-it/src/test/resources/test-child/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/test-child/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.abc</groupId>
+	<artifactId>test-child</artifactId>
+	<version>1.0.0</version>
+	<packaging>mule-application</packaging>
+
+	<name>test-child</name>
+
+	<parent>
+		<groupId>com.abc</groupId>
+		<artifactId>test-parent-pom</artifactId>
+		<version>${revision}</version> 
+		<relativePath>../test-parent-pom</relativePath>
+	</parent>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+		<app.runtime>4.3.0-20210622</app.runtime>
+		
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.0.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.2.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.mule.tools.maven</groupId>
+				<artifactId>mule-maven-plugin</artifactId>
+				<version>${mule.maven.plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<classifier>mule-plugin</classifier>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<id>anypoint-exchange-v2</id>
+			<name>Anypoint Exchange</name>
+			<url>https://maven.anypoint.mulesoft.com/api/v2/maven</url>
+			<layout>default</layout>
+		</repository>
+		<repository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<layout>default</layout>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<layout>default</layout>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/test-child/src/main/mule/test-lib-project.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/test-child/src/main/mule/test-lib-project.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+	<sub-flow name="test-lib-projectSub_Flow" doc:id="86b68c4d-2516-413b-bc5a-0347531030d6" >
+		<logger level="INFO" doc:name="Logger" doc:id="edf22e7e-7bc7-41b9-b8fa-fa1ff522e4cb" message="Test Message"/>
+	</sub-flow>
+</mule>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/test-parent-pom/mule-artifact.json
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/test-parent-pom/mule-artifact.json
@@ -1,0 +1,3 @@
+{
+  "minMuleVersion": "4.3.0"
+}

--- a/mule-artifact-it/mule-packager-it/src/test/resources/test-parent-pom/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/test-parent-pom/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.abc</groupId>
+	<artifactId>test-parent-pom</artifactId>
+	<version>${revision}</version>
+	<packaging>pom</packaging>
+
+	<name>test-parent-pom</name>
+
+	<properties>
+		<revision>1.0.0</revision>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+		<app.runtime>4.3.0-20210622</app.runtime>
+		<mule.maven.plugin.version>3.7.0-SNAPSHOT</mule.maven.plugin.version>
+		<mule-http-connector.mw.version>1.5.23</mule-http-connector.mw.version>
+		<mule-sockets-connector.mw.version>1.2.1</mule-sockets-connector.mw.version>
+		
+		<!-- Maven CI-friendly plugin to implement ${revision} -->
+		<flatten-maven-plugin.mw.version>1.1.0</flatten-maven-plugin.mw.version>
+		
+		<!-- Version of the library project -->
+		<test-lib-project.mw.version>1.0.0</test-lib-project.mw.version>
+		
+		<!-- Email connector version that is specifically used in the library project -->
+		<mule-email-connector.mw.version>1.5.2</mule-email-connector.mw.version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.0.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.mule.tools.maven</groupId>
+				<artifactId>mule-maven-plugin</artifactId>
+				<version>${mule.maven.plugin.version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>${flatten-maven-plugin.mw.version}</version>
+				<configuration>
+					<updatePomFile>true</updatePomFile>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+				</configuration>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>flatten.clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.abc</groupId>
+				<artifactId>test-lib-project</artifactId>
+				<version>${test-lib-project.mw.version}</version>
+				<classifier>mule-plugin</classifier>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	
+	<dependencies>
+		<dependency>
+			<groupId>org.mule.connectors</groupId>
+			<artifactId>mule-http-connector</artifactId>
+			<version>${mule-http-connector.mw.version}</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>anypoint-exchange-v2</id>
+			<name>Anypoint Exchange</name>
+			<url>https://maven.anypoint.mulesoft.com/api/v2/maven</url>
+			<layout>default</layout>
+		</repository>
+		<repository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<layout>default</layout>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<layout>default</layout>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/test-relative-path/mule-artifact.json
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/test-relative-path/mule-artifact.json
@@ -1,0 +1,3 @@
+{
+  "minMuleVersion": "4.3.0"
+}

--- a/mule-artifact-it/mule-packager-it/src/test/resources/test-relative-path/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/test-relative-path/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.abc</groupId>
+	<artifactId>test-relative-path</artifactId>
+	<version>1.0.0</version>
+	<packaging>mule-application</packaging>
+
+	<name>test-relative-path</name>
+	
+	<parent>
+		<groupId>com.abc</groupId>
+		<artifactId>test-parent-pom</artifactId>
+		
+		<version>${revision}</version>
+		<relativePath>../test-parent-pom</relativePath>
+		
+	</parent>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+		<app.runtime>4.3.0-20210622</app.runtime>
+		<mule.maven.plugin.version>3.5.2</mule.maven.plugin.version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.0.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.mule.tools.maven</groupId>
+				<artifactId>mule-maven-plugin</artifactId>
+				<version>${mule.maven.plugin.version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mule.connectors</groupId>
+			<artifactId>mule-http-connector</artifactId>
+			<version>${mule-http-connector.mw.version}</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+		<!-- Declaration of dependency in child project and referring the property
+		from parent NOT WORKING -->
+		
+		<dependency>
+			<groupId>org.mule.connectors</groupId>
+			<artifactId>mule-sockets-connector</artifactId>
+			<version>${mule-sockets-connector.mw.version}</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
+		
+		<dependency>
+				<groupId>com.abc</groupId>
+				<artifactId>test-child</artifactId>
+				<version>${test-lib-project.mw.version}</version>
+				<classifier>mule-plugin</classifier>
+		</dependency>
+		
+		
+	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>anypoint-exchange-v2</id>
+			<name>Anypoint Exchange</name>
+			<url>https://maven.anypoint.mulesoft.com/api/v2/maven</url>
+			<layout>default</layout>
+		</repository>
+		<repository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<layout>default</layout>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>mulesoft-releases</id>
+			<name>MuleSoft Releases Repository</name>
+			<layout>default</layout>
+			<url>https://repository.mulesoft.org/releases/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/test-relative-path/src/main/mule/test-child-api-project.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/test-relative-path/src/main/mule/test-child-api-project.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core"
+	xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+	<import doc:name="Import" doc:id="e12d0096-4ab4-4ee9-bac1-340707f88cc8" file="test-lib-project.xml" />
+	<http:listener-config name="HTTP_Listener_config" doc:name="HTTP Listener config" doc:id="27ab09f4-36bd-4b27-b9c4-2dc0309ccca2" >
+		<http:listener-connection host="0.0.0.0" port="8081" />
+	</http:listener-config>
+	<flow name="test-child-api-projectFlow" doc:id="008b89b0-24b5-4a7f-9c71-599e0cf6de93" >
+		<http:listener doc:name="Listener" doc:id="23f716cf-6b2c-4d1f-9c8f-12bce6d292fb" config-ref="HTTP_Listener_config" path="/test-api"/>
+		<flow-ref doc:name="Flow Reference" doc:id="450ddf95-bb30-4fb4-a5d1-822631125ef0" name="test-child-api-projectFlow"/>
+	</flow>
+</mule>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/test-relative-path/src/main/resources/application-types.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/test-relative-path/src/main/resources/application-types.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<types:mule xmlns:types="http://www.mulesoft.org/schema/mule/types">
+  <types:catalog/>
+</types:mule>

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/AbstractMuleMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/AbstractMuleMojo.java
@@ -61,7 +61,7 @@ public abstract class AbstractMuleMojo extends AbstractGenericMojo {
 
   public ContentGenerator getContentGenerator() {
     if (contentGenerator == null) {
-      contentGenerator = ContentGeneratorFactory.create(getProjectInformation());
+      contentGenerator = ContentGeneratorFactory.create(getProjectInformation(), project.getModel().getParent());
     }
     return contentGenerator;
   }

--- a/mule-packager/src/main/java/org/mule/tools/api/packager/sources/ContentGenerator.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/packager/sources/ContentGenerator.java
@@ -15,13 +15,28 @@ import static org.mule.tools.api.packager.structure.FolderNames.MAVEN;
 import static org.mule.tools.api.packager.structure.FolderNames.META_INF;
 import static org.mule.tools.api.packager.structure.PackagerFiles.POM_PROPERTIES;
 import static org.mule.tools.api.packager.structure.PackagerFiles.POM_XML;
-import org.mule.tools.api.packager.ProjectInformation;
 
+import org.apache.maven.model.Parent;
+import org.mule.tools.api.packager.ProjectInformation;
+import org.mule.tools.api.util.XmlFactoryUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
 /**
  * Generates the required content for each of the mandatory folders of a mule package
@@ -29,11 +44,13 @@ import java.nio.file.StandardCopyOption;
 public abstract class ContentGenerator {
 
   protected final ProjectInformation projectInformation;
+  private Parent parent;
 
-  public ContentGenerator(ProjectInformation projectInformation) {
+  public ContentGenerator(ProjectInformation projectInformation, Parent parent) {
     checkArgument(projectInformation.getProjectBaseFolder().toFile().exists(), "Project base folder should exist");
     checkArgument(projectInformation.getBuildDirectory().toFile().exists(), "Project build folder should exist");
     this.projectInformation = projectInformation;
+    this.parent = parent;
   }
 
   /**
@@ -51,8 +68,31 @@ public abstract class ContentGenerator {
         projectInformation.getBuildDirectory().resolve(META_INF.value()).resolve(MAVEN.value())
             .resolve(projectInformation.getGroupId()).resolve(projectInformation.getArtifactId());
     String destinationFileName = originPath.getFileName().toString();
-
-    copyFile(originPath, destinationPath, destinationFileName);
+    try {
+      if (parent != null && parent.getRelativePath() != null) {
+        javax.xml.parsers.DocumentBuilderFactory factory = XmlFactoryUtils.createSecureDocumentBuilderFactory();
+        Document pomFile = factory.newDocumentBuilder().parse(originPath.toFile());
+        if (pomFile != null && pomFile.getDocumentElement() != null) {
+          Node parentNode = pomFile.getElementsByTagName("parent").item(0);
+          NodeList parentNodes = parentNode.getChildNodes();
+          for (int i = 0; i < parentNodes.getLength(); i++) {
+            if (parentNodes.item(i).getNodeName().equals("version")) {
+              parentNodes.item(i).getFirstChild().setNodeValue(parent.getVersion());
+            }
+          }
+        }
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        Transformer transformer = transformerFactory.newTransformer();
+        DOMSource source = new DOMSource(pomFile);
+        FileWriter writer = new FileWriter(destinationPath.resolve(destinationFileName).toFile());
+        StreamResult result = new StreamResult(writer);
+        transformer.transform(source, result);
+      } else {
+        copyFile(originPath, destinationPath, destinationFileName);
+      }
+    } catch (SAXException | IOException | ParserConfigurationException | TransformerException | NullPointerException e) {
+      copyFile(originPath, destinationPath, destinationFileName);
+    }
   }
 
   public static void checkPathExist(Path path) {

--- a/mule-packager/src/main/java/org/mule/tools/api/packager/sources/ContentGeneratorFactory.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/packager/sources/ContentGeneratorFactory.java
@@ -10,6 +10,7 @@
 
 package org.mule.tools.api.packager.sources;
 
+import org.apache.maven.model.Parent;
 import org.mule.tools.api.packager.ProjectInformation;
 import org.mule.tools.api.packager.packaging.PackagingType;
 
@@ -20,8 +21,12 @@ import org.mule.tools.api.packager.packaging.PackagingType;
 public class ContentGeneratorFactory {
 
   public static ContentGenerator create(ProjectInformation projectInformation) {
+    return create(projectInformation, null);
+  }
+
+  public static ContentGenerator create(ProjectInformation projectInformation, Parent parent) {
     PackagingType packaging = PackagingType.fromString(projectInformation.getPackaging());
     return packaging == PackagingType.MULE_DOMAIN_BUNDLE ? new DomainBundleContentGenerator(projectInformation)
-        : new MuleContentGenerator(projectInformation);
+        : new MuleContentGenerator(projectInformation, parent);
   }
 }

--- a/mule-packager/src/main/java/org/mule/tools/api/packager/sources/DomainBundleContentGenerator.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/packager/sources/DomainBundleContentGenerator.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 public class DomainBundleContentGenerator extends ContentGenerator {
 
   public DomainBundleContentGenerator(ProjectInformation projectInformation) {
-    super(projectInformation);
+    super(projectInformation, null);
   }
 
   @Override

--- a/mule-packager/src/main/java/org/mule/tools/api/packager/sources/MuleContentGenerator.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/packager/sources/MuleContentGenerator.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.model.Parent;
 
 
 /**
@@ -48,8 +49,8 @@ public class MuleContentGenerator extends ContentGenerator {
 
   private MuleArtifactContentResolver muleArtifactContentResolver;
 
-  public MuleContentGenerator(ProjectInformation projectInformation) {
-    super(projectInformation);
+  public MuleContentGenerator(ProjectInformation projectInformation, Parent parent) {
+    super(projectInformation, parent);
   }
 
   /**

--- a/mule-packager/src/test/java/org/mule/tools/api/ContentGeneratorTest.java
+++ b/mule-packager/src/test/java/org/mule/tools/api/ContentGeneratorTest.java
@@ -66,7 +66,7 @@ public class ContentGeneratorTest {
         .withDependencyProject(mock(Project.class))
         .withResolvedPom(mock(Pom.class))
         .build();
-    contentGenerator = new MuleContentGenerator(info);
+    contentGenerator = new MuleContentGenerator(info, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -79,8 +79,9 @@ public class ContentGeneratorTest {
         .withProjectBaseFolder(Paths.get("/fake/project/base/folder"))
         .setTestProject(false)
         .withBuildDirectory(projectTargetFolder.toPath()).build();
-    new MuleContentGenerator(info);
+    new MuleContentGenerator(info, null);
   }
+
 
   @Test(expected = IllegalArgumentException.class)
   public void failCreationProjectTargetFolderNonExistent() {
@@ -92,7 +93,7 @@ public class ContentGeneratorTest {
         .withProjectBaseFolder(projectBaseFolder.getRoot().toPath())
         .setTestProject(false)
         .withBuildDirectory(Paths.get("/fake/project/base/folder")).build();
-    new MuleContentGenerator(info);
+    new MuleContentGenerator(info, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -282,7 +283,7 @@ public class ContentGeneratorTest {
         .withDependencyProject(mock(Project.class))
         .withResolvedPom(mock(Pom.class))
         .withBuildDirectory(projectTargetFolder.toPath()).build();
-    contentGenerator = new MuleContentGenerator(info);
+    contentGenerator = new MuleContentGenerator(info, null);
 
     String descriptorFileName = MULE_ARTIFACT_DESCRIPTOR_FILE_NAME;
 
@@ -323,7 +324,7 @@ public class ContentGeneratorTest {
         .withDependencyProject(mock(Project.class))
         .withResolvedPom(mock(Pom.class))
         .withBuildDirectory(projectTargetFolder.toPath()).build();
-    contentGenerator = new MuleContentGenerator(info);
+    contentGenerator = new MuleContentGenerator(info, null);
 
     String descriptorFileName = MULE_ARTIFACT_DESCRIPTOR_FILE_NAME;
 


### PR DESCRIPTION
* W-11327063: Packaging not working properly having...

a mule-lib that uses a parent pom that is referenced using a parent's
property as version.

The pom generated by maven-jar-plugin in the same scenario has the
version copied from the parent when it's installed. We need to do this
for relativepath cases.

* removing commas