### PR TITLE
W-11524895: Disable default CloudHub log4j2 settings when deploying applications

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/client/cloudhub/model/Application.java
+++ b/mule-deployer/src/main/java/org/mule/tools/client/cloudhub/model/Application.java
@@ -34,6 +34,7 @@ public class Application {
   private Boolean persistentQueues;
   private Boolean persistentQueuesEncryptionEnabled;
   private Boolean persistentQueuesEncrypted;
+  private Boolean loggingCustomLog4JEnabled;
   private Boolean monitoringEnabled;
   private Boolean monitoringAutoRestart;
   private Boolean staticIPsEnabled;
@@ -189,6 +190,14 @@ public class Application {
 
   public void setPersistentQueuesEncrypted(Boolean persistentQueuesEncrypted) {
     this.persistentQueuesEncrypted = persistentQueuesEncrypted;
+  }
+
+  public Boolean getLoggingCustomLog4JEnabled() {
+    return loggingCustomLog4JEnabled;
+  }
+
+  public void setLoggingCustomLog4JEnabled(Boolean loggingCustomLog4JEnabled) {
+    this.loggingCustomLog4JEnabled = loggingCustomLog4JEnabled;
   }
 
   public Boolean getMonitoringEnabled() {

--- a/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
+++ b/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
@@ -232,7 +232,7 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
 
     application.setObjectStoreV1(!deployment.getObjectStoreV2());
     application.setPersistentQueues(deployment.getPersistentQueues());
-    application.setLoggingCustomLog4JEnabled(deployment.getLoggingCustomLog4JEnabled());
+    application.setLoggingCustomLog4JEnabled(deployment.getDisableCloudHubLogs());
 
     return application;
   }

--- a/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
+++ b/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
@@ -232,6 +232,7 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
 
     application.setObjectStoreV1(!deployment.getObjectStoreV2());
     application.setPersistentQueues(deployment.getPersistentQueues());
+    application.setLoggingCustomLog4JEnabled(deployment.getLoggingCustomLog4JEnabled());
 
     return application;
   }

--- a/mule-deployer/src/main/java/org/mule/tools/model/anypoint/CloudHubDeployment.java
+++ b/mule-deployer/src/main/java/org/mule/tools/model/anypoint/CloudHubDeployment.java
@@ -38,6 +38,9 @@ public class CloudHubDeployment extends AnypointDeployment {
   protected Boolean persistentQueues = false;
 
   @Parameter
+  protected Boolean LoggingCustomLog4JEnabled = false;
+
+  @Parameter
   protected Integer waitBeforeValidation = 6000;
 
   @Parameter
@@ -106,6 +109,14 @@ public class CloudHubDeployment extends AnypointDeployment {
 
   public void setPersistentQueues(Boolean persistentQueues) {
     this.persistentQueues = persistentQueues;
+  }
+
+  public Boolean getLoggingCustomLog4JEnabled() {
+    return LoggingCustomLog4JEnabled;
+  }
+
+  public void setLoggingCustomLog4JEnabled(Boolean LoggingCustomLog4JEnabled) {
+    this.LoggingCustomLog4JEnabled = LoggingCustomLog4JEnabled;
   }
 
   public Integer getWaitBeforeValidation() {

--- a/mule-deployer/src/main/java/org/mule/tools/model/anypoint/CloudHubDeployment.java
+++ b/mule-deployer/src/main/java/org/mule/tools/model/anypoint/CloudHubDeployment.java
@@ -38,7 +38,7 @@ public class CloudHubDeployment extends AnypointDeployment {
   protected Boolean persistentQueues = false;
 
   @Parameter
-  protected Boolean LoggingCustomLog4JEnabled = false;
+  protected Boolean disableCloudHubLogs = false;
 
   @Parameter
   protected Integer waitBeforeValidation = 6000;
@@ -111,12 +111,12 @@ public class CloudHubDeployment extends AnypointDeployment {
     this.persistentQueues = persistentQueues;
   }
 
-  public Boolean getLoggingCustomLog4JEnabled() {
-    return LoggingCustomLog4JEnabled;
+  public Boolean getDisableCloudHubLogs() {
+    return disableCloudHubLogs;
   }
 
-  public void setLoggingCustomLog4JEnabled(Boolean LoggingCustomLog4JEnabled) {
-    this.LoggingCustomLog4JEnabled = LoggingCustomLog4JEnabled;
+  public void setDisableCloudHubLogs(Boolean disableCloudHubLogs) {
+    this.disableCloudHubLogs = disableCloudHubLogs;
   }
 
   public Integer getWaitBeforeValidation() {

--- a/mule-deployer/src/test/java/org/mule/tools/model/anypoint/CloudHubDeploymentTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/model/anypoint/CloudHubDeploymentTest.java
@@ -59,6 +59,12 @@ public class CloudHubDeploymentTest {
   }
 
   @Test
+  public void defaultLoggingCustomLog4JEnabledValueIsFalse() {
+    assertThat("The default value for Custom Log4J property is not false",
+               deploymentSpy.getLoggingCustomLog4JEnabled(), equalTo(false));
+  }
+
+  @Test
   public void defaultWaitBeforeValidationIsZero() {
     assertThat("The default value for pepe is not zero",
                deploymentSpy.getWaitBeforeValidation(), equalTo(6000));

--- a/mule-deployer/src/test/java/org/mule/tools/model/anypoint/CloudHubDeploymentTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/model/anypoint/CloudHubDeploymentTest.java
@@ -59,9 +59,9 @@ public class CloudHubDeploymentTest {
   }
 
   @Test
-  public void defaultLoggingCustomLog4JEnabledValueIsFalse() {
+  public void defaultDisableCloudHubLogsValueIsFalse() {
     assertThat("The default value for Custom Log4J property is not false",
-               deploymentSpy.getLoggingCustomLog4JEnabled(), equalTo(false));
+               deploymentSpy.getDisableCloudHubLogs(), equalTo(false));
   }
 
   @Test


### PR DESCRIPTION
Based on this [entry](https://help.mulesoft.com/s/ideas#08734000000HV2fAAG) from the ideas portal.
The idea is to add a way to handle the _loggingCustomLog4JEnabled_ property when deploying an application to CloudHub, which, at the moment, can only be done by following [this article](https://help.mulesoft.com/s/article/How-to-disable-CloudHub-logging-using-API)