### PR TITLE
list the supported target names in the error message

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/deployment/fabric/RequestBuilder.java
+++ b/mule-deployer/src/main/java/org/mule/tools/deployment/fabric/RequestBuilder.java
@@ -27,7 +27,9 @@ import org.mule.tools.model.anypoint.RuntimeFabricDeployment;
 import org.mule.tools.model.anypoint.RuntimeFabricDeploymentSettings;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class RequestBuilder {
 
@@ -140,6 +142,7 @@ public class RequestBuilder {
   }
 
   public static String getTargetId(JsonArray targets, String targetName) throws DeploymentException {
+	Set<String> currentTargetNames = new HashSet<>();
     for (JsonElement targetElement : targets) {
       JsonObject target = targetElement.getAsJsonObject();
       if (target != null) {
@@ -148,11 +151,13 @@ public class RequestBuilder {
           String currentTargetName = nameElement.getAsString();
           if (StringUtils.equals(targetName, currentTargetName)) {
             return target.get(ID).getAsString();
+          } else {
+        	currentTargetNames.add(currentTargetName);
           }
         }
       }
     }
-    throw new DeploymentException("Could not find target " + targetName);
+    throw new DeploymentException("Could not find target " + targetName + " in " + currentTargetNames);
   }
 
   protected ApplicationRequest buildApplicationRequest() {


### PR DESCRIPTION
The cloudhub 2.0 target attribute is not really documented
( https://docs.mulesoft.com/mule-runtime/4.4/deploy-to-cloudhub-2#cloudhub2-deploy-reference )
`<target>afm-ps</target>`

and maven goal just fails with

"Could not find target".

Better is to list the supported target names in the error message.