### PR TITLE
W-11068928:Mule Maven Plugin 3.6.0 failing to validate XML in Reconnection Strategy element when the values are set with property placeholders instead of inline number values

### DIFF
--- a/mule-extension-model-loader/pom.xml
+++ b/mule-extension-model-loader/pom.xml
@@ -26,17 +26,17 @@
         <dependency>
             <groupId> org.mule.runtime</groupId>
             <artifactId>mule-module-logging</artifactId>
-            <version>4.5.0-20220221</version>
+            <version>${mule.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-artifact-ast-xml-parser</artifactId>
-            <version>1.1.0-20220523</version>
+            <version>1.1.0-20220824</version>
         </dependency>
          <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-artifact-ast-serialization</artifactId>
-             <version>1.1.0-20220523</version>
+             <version>1.1.0-20220824</version>
         </dependency>
         <dependency>
             <groupId>com.mulesoft.anypoint</groupId>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.mule</groupId>
             <artifactId>mule-maven-client-impl</artifactId>
-            <version>1.6.0</version>
+            <version>${mule.maven.client.impl.version}</version>
         </dependency>
         <!-- Test dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <mule.version>4.5.0-20220622</mule.version>
-        <mule.api.version>1.5.0-20220523</mule.api.version>
+        <mule.api.version>1.5.0-20220622</mule.api.version>
         <mule.maven.client.impl.version>1.6.0</mule.maven.client.impl.version>
         <mule.distribution.standalone.version>4.4.0</mule.distribution.standalone.version>
         <gson.version>2.8.6</gson.version>
@@ -61,7 +61,7 @@
         <commons.lang.version>3.10</commons.lang.version>
         <commons.collections.version>4.4</commons.collections.version>
         <commons.cli.version>1.4</commons.cli.version>
-        <commons.compress.version>1.20</commons.compress.version>
+        <commons.compress.version>1.21</commons.compress.version>
         <slf4j.api.version>1.8.0-beta2</slf4j.api.version>
         <commons.logging.version>1.2</commons.logging.version>
         <jdom2.version>2.0.6</jdom2.version>


### PR DESCRIPTION
The problem was fixed in mule-artifact-ast-xml-parser. I'm updating other runtime dependencies too(just to keep it up to date). I'm also updating commons-compress to fix a vulnerability