### PR TITLE
W-11727183:Updating windows agent (cherrypick)

### DIFF
--- a/integrationTests-Windows.jenkinsfile
+++ b/integrationTests-Windows.jenkinsfile
@@ -9,7 +9,7 @@ properties([
 ])
 
 def pipelineParams = [
-  "agent": "windows7",
+  "agent": "windows10",
   "jdk": params.JDK,
   "maven": params.maven
 ]


### PR DESCRIPTION
because w7 is not available anymore in jenkins