### PR TITLE
W-11771239: Update Mule lifecycles plugins versions

### DIFF
--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/DomainBundleLifecycleMapping.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/DomainBundleLifecycleMapping.java
@@ -22,6 +22,8 @@ import java.util.Map;
 
 import static org.mule.tools.maven.mojo.model.lifecycle.MavenLifecyclePhase.*;
 import static org.mule.tools.maven.mojo.model.lifecycle.MavenLifecyclePhase.DEPLOY;
+import static org.mule.tools.maven.mojo.model.lifecycle.mapping.project.LifecyclePluginsGAVs.MAVEN_DEPLOY_PLUGIN;
+import static org.mule.tools.maven.mojo.model.lifecycle.mapping.project.LifecyclePluginsGAVs.MAVEN_INSTALL_PLUGIN;
 
 public class DomainBundleLifecycleMapping implements LifecycleMapping, ProjectLifecycleMapping {
 
@@ -54,13 +56,13 @@ public class DomainBundleLifecycleMapping implements LifecycleMapping, ProjectLi
     phases.put(GENERATE_SOURCES.id(), mapping.buildGoals("org.mule.tools.maven:mule-maven-plugin:generate-sources"));
     phases.put(PACKAGE.id(), mapping.buildGoals("org.mule.tools.maven:mule-maven-plugin:package"));
     phases.put(VERIFY.id(), mapping.buildGoals("org.mule.tools.maven:mule-maven-plugin:verify"));
-    phases.put(INSTALL.id(), mapping.buildGoals("org.apache.maven.plugins:maven-install-plugin:3.0.1:install"));
+    phases.put(INSTALL.id(), mapping.buildGoals(MAVEN_INSTALL_PLUGIN + ":install"));
 
     String isMuleDeploy = System.getProperty(MULE_DEPLOY);
     if (isMuleDeploy != null && isMuleDeploy.equals("true")) {
       phases.put(DEPLOY.id(), mapping.buildGoals("org.mule.tools.maven:mule-maven-plugin:deploy"));
     } else {
-      phases.put(DEPLOY.id(), mapping.buildGoals("org.apache.maven.plugins:maven-deploy-plugin:3.0.0:deploy"));
+      phases.put(DEPLOY.id(), mapping.buildGoals(MAVEN_DEPLOY_PLUGIN + ":deploy"));
     }
     return phases;
   }

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/DomainBundleLifecycleMapping.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/DomainBundleLifecycleMapping.java
@@ -54,13 +54,13 @@ public class DomainBundleLifecycleMapping implements LifecycleMapping, ProjectLi
     phases.put(GENERATE_SOURCES.id(), mapping.buildGoals("org.mule.tools.maven:mule-maven-plugin:generate-sources"));
     phases.put(PACKAGE.id(), mapping.buildGoals("org.mule.tools.maven:mule-maven-plugin:package"));
     phases.put(VERIFY.id(), mapping.buildGoals("org.mule.tools.maven:mule-maven-plugin:verify"));
-    phases.put(INSTALL.id(), mapping.buildGoals("org.apache.maven.plugins:maven-install-plugin:2.5.2:install"));
+    phases.put(INSTALL.id(), mapping.buildGoals("org.apache.maven.plugins:maven-install-plugin:3.0.1:install"));
 
     String isMuleDeploy = System.getProperty(MULE_DEPLOY);
     if (isMuleDeploy != null && isMuleDeploy.equals("true")) {
       phases.put(DEPLOY.id(), mapping.buildGoals("org.mule.tools.maven:mule-maven-plugin:deploy"));
     } else {
-      phases.put(DEPLOY.id(), mapping.buildGoals("org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy"));
+      phases.put(DEPLOY.id(), mapping.buildGoals("org.apache.maven.plugins:maven-deploy-plugin:3.0.0:deploy"));
     }
     return phases;
   }

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/LifecyclePluginsGAVs.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/LifecyclePluginsGAVs.java
@@ -1,0 +1,26 @@
+package org.mule.tools.maven.mojo.model.lifecycle.mapping.project;
+/*
+ * Mule ESB Maven Tools
+ * <p>
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * <p>
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+public class LifecyclePluginsGAVs {
+
+  private static final String ORG_APACHE_MAVEN_PLUGINS = "org.apache.maven.plugins";
+  private static final String EXCHANGE_PLUGIN = "org.mule.tools.maven";
+
+  static final String MAVEN_RESOURCES_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-resources-plugin:3.3.0";
+  static final String MAVEN_CLEAN_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-clean-plugin:3.2.0";
+  static final String MAVEN_COMPILER_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-compiler-plugin:3.10.1";
+  static final String MAVEN_SUREFIRE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-surefire-plugin:3.0.0-M7";
+  static final String MAVEN_INSTALL_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-install-plugin:3.0.1";
+  static final String MAVEN_DEPLOY_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-deploy-plugin:3.0.0";
+  static final String MAVEN_SITE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-site-plugin:3.12.1";
+
+  static final String EXCHANGE_PUBLICATION_PLUGIN = EXCHANGE_PLUGIN + ":exchange-mule-maven-plugin:0.0.17";
+}

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/MuleLifecycleMapping.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/MuleLifecycleMapping.java
@@ -28,6 +28,15 @@ import static org.mule.tools.maven.mojo.model.lifecycle.MavenLifecyclePhase.TEST
 import static org.mule.tools.maven.mojo.model.lifecycle.MavenLifecyclePhase.VALIDATE;
 import static org.mule.tools.maven.mojo.model.lifecycle.MavenLifecyclePhase.VERIFY;
 
+import static org.mule.tools.maven.mojo.model.lifecycle.mapping.project.LifecyclePluginsGAVs.MAVEN_RESOURCES_PLUGIN;
+import static org.mule.tools.maven.mojo.model.lifecycle.mapping.project.LifecyclePluginsGAVs.MAVEN_CLEAN_PLUGIN;
+import static org.mule.tools.maven.mojo.model.lifecycle.mapping.project.LifecyclePluginsGAVs.MAVEN_COMPILER_PLUGIN;
+import static org.mule.tools.maven.mojo.model.lifecycle.mapping.project.LifecyclePluginsGAVs.MAVEN_SUREFIRE_PLUGIN;
+import static org.mule.tools.maven.mojo.model.lifecycle.mapping.project.LifecyclePluginsGAVs.MAVEN_INSTALL_PLUGIN;
+import static org.mule.tools.maven.mojo.model.lifecycle.mapping.project.LifecyclePluginsGAVs.MAVEN_DEPLOY_PLUGIN;
+import static org.mule.tools.maven.mojo.model.lifecycle.mapping.project.LifecyclePluginsGAVs.MAVEN_SITE_PLUGIN;
+import static org.mule.tools.maven.mojo.model.lifecycle.mapping.project.LifecyclePluginsGAVs.EXCHANGE_PUBLICATION_PLUGIN;
+
 import org.mule.tools.maven.mojo.model.lifecycle.mapping.version.LifecycleMappingMaven333;
 import org.mule.tools.maven.mojo.model.lifecycle.mapping.version.LifecycleMappingMavenFactory;
 import org.mule.tools.maven.mojo.model.lifecycle.mapping.version.LifecycleMappingMavenVersionless;
@@ -44,18 +53,7 @@ public class MuleLifecycleMapping implements LifecycleMapping, ProjectLifecycleM
 
   private static final String MULE_DEPLOY = "muleDeploy";
 
-  private static final String ORG_APACHE_MAVEN_PLUGINS = "org.apache.maven.plugins";
   private static final String MULE_MAVEN_PLUGIN = "org.mule.tools.maven:mule-maven-plugin";
-  private static final String EXCHANGE_PLUGIN = "org.mule.tools.maven";
-
-  private static final String MAVEN_RESOURCES_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-resources-plugin:3.3.0";
-  private static final String MAVEN_CLEAN_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-clean-plugin:3.2.0";
-  private static final String MAVEN_COMPILER_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-compiler-plugin:3.10.1";
-  private static final String MAVEN_SUREFIRE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-surefire-plugin:3.0.0-M7";
-  private static final String MAVEN_INSTALL_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-install-plugin:3.0.1";
-  private static final String MAVEN_DEPLOY_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-deploy-plugin:3.0.0";
-  private static final String MAVEN_SITE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-site-plugin:3.12.1";
-  private static final String EXCHANGE_PUBLICATION_PLUGIN = EXCHANGE_PLUGIN + ":exchange-mule-maven-plugin:0.0.17";
 
   @Override
   public List<String> getOptionalMojos(String lifecycle) {

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/MuleLifecycleMapping.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/MuleLifecycleMapping.java
@@ -48,13 +48,13 @@ public class MuleLifecycleMapping implements LifecycleMapping, ProjectLifecycleM
   private static final String MULE_MAVEN_PLUGIN = "org.mule.tools.maven:mule-maven-plugin";
   private static final String EXCHANGE_PLUGIN = "org.mule.tools.maven";
 
-  private static final String MAVEN_RESOURCES_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-resources-plugin:3.0.2";
-  private static final String MAVEN_CLEAN_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-clean-plugin:3.1.0";
-  private static final String MAVEN_COMPILER_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-compiler-plugin:3.8.1";
-  private static final String MAVEN_SUREFIRE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-surefire-plugin:2.19.1";
-  private static final String MAVEN_INSTALL_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-install-plugin:2.5.2";
-  private static final String MAVEN_DEPLOY_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-deploy-plugin:2.8.2";
-  private static final String MAVEN_SITE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-site-plugin:3.8.2";
+  private static final String MAVEN_RESOURCES_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-resources-plugin:3.3.0";
+  private static final String MAVEN_CLEAN_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-clean-plugin:3.2.0";
+  private static final String MAVEN_COMPILER_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-compiler-plugin:3.10.1";
+  private static final String MAVEN_SUREFIRE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-surefire-plugin:3.0.0-M7";
+  private static final String MAVEN_INSTALL_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-install-plugin:3.0.1";
+  private static final String MAVEN_DEPLOY_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-deploy-plugin:3.0.0";
+  private static final String MAVEN_SITE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-site-plugin:3.12.1";
   private static final String EXCHANGE_PUBLICATION_PLUGIN = EXCHANGE_PLUGIN + ":exchange-mule-maven-plugin:0.0.17";
 
   @Override

--- a/mule-packager/src/main/java/org/mule/tools/api/packager/sources/MuleArtifactContentResolver.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/packager/sources/MuleArtifactContentResolver.java
@@ -18,8 +18,6 @@ import org.mule.tools.api.packager.Pom;
 import org.mule.tools.api.packager.structure.ProjectStructure;
 import org.mule.tools.api.util.XmlFactoryUtils;
 
-import com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;


### PR DESCRIPTION
Several current defined versions of plugins used by the Mule lifecycle had dependency on plexus-utils < 3.0.16 so they are impacted by CVE-2017-1000487 and it is causing part of W-11745229.