### PR TITLE
W-11369839:Mule Maven Plugin AST Generation failing when certain exception types selected in Error Handler

### DIFF
--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/pom.xml
@@ -36,6 +36,12 @@
 	</build>
 
 	<dependencies>
+			<dependency>
+			<groupId>org.mule.modules</groupId>
+			<artifactId>mule-apikit-module</artifactId>
+			<version>1.6.0</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
 		<dependency>
 			<groupId>org.mule.connectors</groupId>
 			<artifactId>mule-http-connector</artifactId>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/src/main/mule/simple-app-with-lib.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/simple-app-with-lib/src/main/mule/simple-app-with-lib.xml
@@ -18,6 +18,11 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 				<ee:set-payload resource="dataweave/set-empty-payload.dwl" />
 			</ee:message>
 		</ee:transform>
+					<error-handler >
+				<on-error-continue enableNotifications="true" logException="true" doc:name="On Error Continue" doc:id="7f7d75a4-a84f-4406-b14d-76abf5f169de" type="HTTP:BAD_GATEWAY" when="(error.errorMessage.payload.^mediaType contains 'application/json') and (error.errorMessage.payload.detail != null)">
+					<set-variable value="409" doc:name="Set HTTP Status 409" doc:id="845ca4a1-096f-48e7-b9d5-62ffb2a3c7fb" variableName="httpStatus"/>
+				</on-error-continue>
+			</error-handler>
 	</flow>
 
 </mule>

--- a/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/AstGeneratorTest.java
+++ b/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/AstGeneratorTest.java
@@ -50,7 +50,7 @@ public class AstGeneratorTest extends MavenClientTest {
                                                                       Optional.ofNullable(getSettingsSecurity(m2Repo))));
     Path workingPath = Paths.get("src", "test", "resources", "test-project");
     Set<Artifact> dependencies = new HashSet<Artifact>();
-    AstGenerator generator = new AstGenerator(client, "4.3.0", dependencies, workingPath, null);
+    AstGenerator generator = new AstGenerator(client, "4.3.0", dependencies, workingPath, null, new ArrayList<Dependency>());
     Path configsBasePath = workingPath.resolve("src/main/mule");
     ArtifactAst artifact =
         generator.generateAST(Arrays.asList(configsBasePath.resolve("mule-config.xml").toFile().getAbsolutePath()),
@@ -70,7 +70,7 @@ public class AstGeneratorTest extends MavenClientTest {
                                                                       Optional.ofNullable(getSettingsSecurity(m2Repo))));
     Path workingPath = Paths.get("src", "test", "resources", "test-project");
     Set<Artifact> dependencies = new HashSet<Artifact>();
-    AstGenerator generator = new AstGenerator(client, "4.3.0", dependencies, workingPath, null);
+    AstGenerator generator = new AstGenerator(client, "4.3.0", dependencies, workingPath, null, new ArrayList<Dependency>());
     Path configsBasePath = workingPath.resolve("src/main/mule");
     ArtifactAst artifact =
         generator.generateAST(Arrays.asList(configsBasePath.resolve("mule-config2.xml").toFile().getAbsolutePath()),

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/ProcessClassesMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/ProcessClassesMojo.java
@@ -96,7 +96,7 @@ public class ProcessClassesMojo extends AbstractMuleMojo {
         .addURL(project.getBasedir().toPath().resolve("src").resolve("main").resolve("resources").toUri().toURL());
     AstGenerator astGenerator = new AstGenerator(getAetherMavenClient(), RUNTIME_AST_VERSION,
                                                  project.getArtifacts(), Paths.get(project.getBuild().getDirectory()),
-                                                 descriptor.getClassRealm());
+                                                 descriptor.getClassRealm(), project.getDependencies());
     ProjectStructure projectStructure = new ProjectStructure(projectBaseFolder.toPath(), false);
     MuleArtifactContentResolver contentResolver =
         new MuleArtifactContentResolver(new ProjectStructure(projectBaseFolder.toPath(), false),


### PR DESCRIPTION
It was failing because a different version of a connector was being resolved transitively. So, now the extension models of the direct dependencies are resolved first