### PR TITLE
CP: W-11524895

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/client/cloudhub/model/Application.java
+++ b/mule-deployer/src/main/java/org/mule/tools/client/cloudhub/model/Application.java
@@ -34,6 +34,7 @@ public class Application {
   private Boolean persistentQueues;
   private Boolean persistentQueuesEncryptionEnabled;
   private Boolean persistentQueuesEncrypted;
+  private Boolean loggingCustomLog4JEnabled;
   private Boolean monitoringEnabled;
   private Boolean monitoringAutoRestart;
   private Boolean staticIPsEnabled;
@@ -189,6 +190,14 @@ public class Application {
 
   public void setPersistentQueuesEncrypted(Boolean persistentQueuesEncrypted) {
     this.persistentQueuesEncrypted = persistentQueuesEncrypted;
+  }
+
+  public Boolean getLoggingCustomLog4JEnabled() {
+    return loggingCustomLog4JEnabled;
+  }
+
+  public void setLoggingCustomLog4JEnabled(Boolean loggingCustomLog4JEnabled) {
+    this.loggingCustomLog4JEnabled = loggingCustomLog4JEnabled;
   }
 
   public Boolean getMonitoringEnabled() {

--- a/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
+++ b/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
@@ -232,6 +232,7 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
 
     application.setObjectStoreV1(!deployment.getObjectStoreV2());
     application.setPersistentQueues(deployment.getPersistentQueues());
+    application.setLoggingCustomLog4JEnabled(deployment.getDisableCloudHubLogs());
 
     return application;
   }

--- a/mule-deployer/src/main/java/org/mule/tools/model/anypoint/CloudHubDeployment.java
+++ b/mule-deployer/src/main/java/org/mule/tools/model/anypoint/CloudHubDeployment.java
@@ -38,6 +38,9 @@ public class CloudHubDeployment extends AnypointDeployment {
   protected Boolean persistentQueues = false;
 
   @Parameter
+  protected Boolean disableCloudHubLogs = false;
+
+  @Parameter
   protected Integer waitBeforeValidation = 6000;
 
   @Parameter
@@ -106,6 +109,14 @@ public class CloudHubDeployment extends AnypointDeployment {
 
   public void setPersistentQueues(Boolean persistentQueues) {
     this.persistentQueues = persistentQueues;
+  }
+
+  public Boolean getDisableCloudHubLogs() {
+    return disableCloudHubLogs;
+  }
+
+  public void setDisableCloudHubLogs(Boolean disableCloudHubLogs) {
+    this.disableCloudHubLogs = disableCloudHubLogs;
   }
 
   public Integer getWaitBeforeValidation() {

--- a/mule-deployer/src/test/java/org/mule/tools/model/anypoint/CloudHubDeploymentTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/model/anypoint/CloudHubDeploymentTest.java
@@ -59,6 +59,12 @@ public class CloudHubDeploymentTest {
   }
 
   @Test
+  public void defaultDisableCloudHubLogsValueIsFalse() {
+    assertThat("The default value for Custom Log4J property is not false",
+               deploymentSpy.getDisableCloudHubLogs(), equalTo(false));
+  }
+
+  @Test
   public void defaultWaitBeforeValidationIsZero() {
     assertThat("The default value for pepe is not zero",
                deploymentSpy.getWaitBeforeValidation(), equalTo(6000));


### PR DESCRIPTION
: Disable default CloudHub log4j2 settings when deploying applications (#607)

* Added loggingCustomLog4JEnabled field to API call when deploying to CloudHub

* Changed 'loggingCustomLog4JEnabled' property name used in cloudHubDeployment to 'disableCloudHubLogs'

Co-authored-by: egrave <eduardograve3@gmail.com>