### PR TITLE
Enable CloudHub logging configuration when deploying applications

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
+++ b/mule-deployer/src/main/java/org/mule/tools/deployment/cloudhub/CloudHubArtifactDeployer.java
@@ -233,6 +233,7 @@ public class CloudHubArtifactDeployer implements ArtifactDeployer {
     application.setObjectStoreV1(!deployment.getObjectStoreV2());
     application.setPersistentQueues(deployment.getPersistentQueues());
     application.setLoggingCustomLog4JEnabled(deployment.getDisableCloudHubLogs());
+    application.setLogLevels(deployment.getLogLevelInfos());
 
     return application;
   }

--- a/mule-deployer/src/main/java/org/mule/tools/model/anypoint/CloudHubDeployment.java
+++ b/mule-deployer/src/main/java/org/mule/tools/model/anypoint/CloudHubDeployment.java
@@ -11,7 +11,10 @@
 package org.mule.tools.model.anypoint;
 
 import org.apache.maven.plugins.annotations.Parameter;
+import org.mule.tools.client.cloudhub.model.LogLevelInfo;
 import org.mule.tools.client.core.exception.DeploymentException;
+
+import java.util.List;
 
 import static java.lang.System.getProperty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -45,6 +48,9 @@ public class CloudHubDeployment extends AnypointDeployment {
 
   @Parameter
   protected Boolean applyLatestRuntimePatch = false;
+
+  @Parameter
+  protected List<LogLevelInfo> logLevelInfos;
 
   /**
    * Region to deploy the application in Cloudhub.
@@ -138,6 +144,17 @@ public class CloudHubDeployment extends AnypointDeployment {
 
   public void setApplyLatestRuntimePatch(Boolean applyLatestRuntimePatch) {
     this.applyLatestRuntimePatch = applyLatestRuntimePatch;
+  }
+
+  /**
+   * Logging configuration to set in Cloudhub.
+   */
+  public List<LogLevelInfo> getLogLevelInfos() {
+    return logLevelInfos;
+  }
+
+  public void setLogLevelInfos(List<LogLevelInfo> logLevelInfos) {
+    this.logLevelInfos = logLevelInfos;
   }
 
   public void setEnvironmentSpecificValues() throws DeploymentException {

--- a/mule-deployer/src/test/java/org/mule/tools/model/anypoint/CloudHubDeploymentTest.java
+++ b/mule-deployer/src/test/java/org/mule/tools/model/anypoint/CloudHubDeploymentTest.java
@@ -75,4 +75,10 @@ public class CloudHubDeploymentTest {
     assertThat("The default value for apply patch property must be false",
                deploymentSpy.getApplyLatestRuntimePatch(), equalTo(false));
   }
+
+  @Test
+  public void defaulLogLevelInfosValueIsNull() {
+    assertThat("The default value for Log Level Infos property is not null",
+               deploymentSpy.getLogLevelInfos(), equalTo(null));
+  }
 }


### PR DESCRIPTION
> * Added logLevels field to API call when deploying to CloudHub
> * Added the optional property logLevelInfos to the CloudHub Deployment Maven Plugin

This PR makes it possible to add a logging configuration, while deploying an application to CloudHub 1 using the Mule Maven Plugin.

_The mule-maven-plugin in a project's pom.xml should be configured as follows:_

```
<build>
...
			<plugin>
				<groupId>org.mule.tools.maven</groupId>
				<artifactId>mule-maven-plugin</artifactId>
				<version>${mule.maven.plugin.version}</version>
				<extensions>true</extensions>
				<configuration>
					...
					<cloudHubDeployment>
                                          ...
						<logLevelInfos>
							<logLevelInfo>
								<packageName>com.muley.test.1</packageName>
								<level>DEBUG</level>
							</logLevelInfo>
							<logLevelInfo>
								<packageName>com.muley.test.2</packageName>
								<level>INFO</level>
							  </logLevelInfo>
						</logLevelInfos>
                                          ...
					</cloudHubDeployment>
				</configuration>
			</plugin>
...
</build>
```

