### PR TITLE
Test fixed that was broken since w-11996025

### DIFF
--- a/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/ExtensionModelLoaderTest.java
+++ b/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/ExtensionModelLoaderTest.java
@@ -56,9 +56,9 @@ public class ExtensionModelLoaderTest extends MavenClientTest {
                                                          .setArtifactId("mule-http-connector")
                                                          .setClassifier("mule-plugin")
                                                          .setVersion("1.5.25").build());
-    assertEquals("Loaded a different amount of runtime extension models than expected", 11,
+    assertEquals("Loaded a different amount of runtime extension models than expected", 10,
                  extensionModelLoader.getRuntimeExtensionModels().size());
-    assertEquals("Loaded a different amount of plugin extension models than expected", 8, http.getExtensionModels().size());
+    assertEquals("Loaded a different amount of plugin extension models than expected", 7, http.getExtensionModels().size());
 
   }
 


### PR DESCRIPTION
DSL won't be included in runtime 4.5.0 GA. That extesion model was removed and that is why the test is failing