### PR TITLE
W-12558941: Applications that depend on mule-module-spring-config can't be packaged

### DIFF
--- a/mule-extension-model-loader/pom.xml
+++ b/mule-extension-model-loader/pom.xml
@@ -100,6 +100,11 @@
             <artifactId>mule-maven-client-impl</artifactId>
             <version>${mule.maven.client.impl.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-module-spring-config</artifactId>
+            <version>${mule.version}</version>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
Changes made:

- Added mule-module-spring-config dependency to mule-extension-model-loader/pom.xml