### PR TITLE
W-12354025: Upgrade to snakeyaml 2.0 to address vulnerability in earrlier  versions

### DIFF
--- a/mule-packager/pom.xml
+++ b/mule-packager/pom.xml
@@ -13,10 +13,6 @@
     <properties>
         <licensePath>../LICENSE_HEADER.txt</licensePath>
         <formatterConfigPath>../formatter.xml</formatterConfigPath>
-
-        <coverageLineLimit>0.74</coverageLineLimit>
-        <coverageBranchLimit>0.69</coverageBranchLimit>
-        <allure.version>2.8.1</allure.version>
     </properties>
 
     <build>

--- a/mule-packager/pom.xml
+++ b/mule-packager/pom.xml
@@ -16,6 +16,7 @@
 
         <coverageLineLimit>0.74</coverageLineLimit>
         <coverageBranchLimit>0.69</coverageBranchLimit>
+        <allure.version>2.8.1</allure.version>
     </properties>
 
     <build>
@@ -124,6 +125,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-java-commons</artifactId>
+            <version>${allure.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/mule-packager/pom.xml
+++ b/mule-packager/pom.xml
@@ -13,6 +13,9 @@
     <properties>
         <licensePath>../LICENSE_HEADER.txt</licensePath>
         <formatterConfigPath>../formatter.xml</formatterConfigPath>
+
+        <coverageLineLimit>0.74</coverageLineLimit>
+        <coverageBranchLimit>0.69</coverageBranchLimit>
     </properties>
 
     <build>

--- a/mule-packager/src/main/java/org/mule/tools/api/verifier/policy/PolicyYamlVerifier.java
+++ b/mule-packager/src/main/java/org/mule/tools/api/verifier/policy/PolicyYamlVerifier.java
@@ -9,17 +9,21 @@
  */
 package org.mule.tools.api.verifier.policy;
 
+import static java.lang.String.format;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
 import org.mule.tools.api.exception.ValidationException;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
-import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.String.format;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.representer.Representer;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 
 public class PolicyYamlVerifier {
 
@@ -33,10 +37,10 @@ public class PolicyYamlVerifier {
 
   public void validate() throws ValidationException {
     try {
-      Representer representer = new Representer();
+      Representer representer = new Representer(new DumperOptions());
       representer.getPropertyUtils().setSkipMissingProperties(true);
 
-      Yaml yamlParser = new Yaml(new Constructor(PolicyYaml.class), representer);
+      Yaml yamlParser = new Yaml(new Constructor(PolicyYaml.class, new LoaderOptions()), representer);
       File yamlFile = new File(path, yamlFileName);
       checkNotNullFields(yamlParser.load(new FileInputStream(yamlFile)));
 

--- a/mule-packager/src/test/java/org/mule/tools/api/verifier/ProjectVerifierFactoryTest.java
+++ b/mule-packager/src/test/java/org/mule/tools/api/verifier/ProjectVerifierFactoryTest.java
@@ -9,20 +9,28 @@
  */
 package org.mule.tools.api.verifier;
 
+import static org.mule.tools.api.packager.packaging.PackagingType.MULE_POLICY;
+
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mule.tools.api.packager.packaging.PackagingType.MULE_POLICY;
 
+import org.mule.tools.api.exception.ValidationException;
+import org.mule.tools.api.verifier.policy.PolicyYamlVerifier;
 import org.mule.tools.api.packager.DefaultProjectInformation;
 import org.mule.tools.api.packager.packaging.PackagingType;
 import org.mule.tools.api.verifier.policy.MulePolicyVerifier;
 
+import java.net.URL;
+import java.net.URISyntaxException;
+
+import io.qameta.allure.Issue;
+import io.qameta.allure.Description;
 import org.junit.Test;
+import org.junit.Test.None;
 
 public class ProjectVerifierFactoryTest {
-
 
   @Test
   public void createPolicyPreparePackagerTest() {
@@ -42,5 +50,14 @@ public class ProjectVerifierFactoryTest {
                    ProjectVerifyFactory.create(defaultProjectInformation), instanceOf(MuleProjectVerifier.class));
       }
     }
+  }
+
+  @Test
+  @Issue("W-12354025")
+  @Description("Verify that PolicyYamlVerifier validation works after upgrading to snakeyaml 2.0")
+  public void verifyValidation() throws ValidationException {
+    PolicyYamlVerifier policyYamlVerifier =
+        new PolicyYamlVerifier(this.getClass().getResource("/org/mule/tools/api/verifier").getPath(), "custom.policy.test.yaml");
+    policyYamlVerifier.validate();
   }
 }

--- a/mule-packager/src/test/java/org/mule/tools/api/verifier/ProjectVerifierFactoryTest.java
+++ b/mule-packager/src/test/java/org/mule/tools/api/verifier/ProjectVerifierFactoryTest.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 
 import io.qameta.allure.Issue;
 import io.qameta.allure.Description;
+import jdk.jfr.Description;
 import org.junit.Test;
 import org.junit.Test.None;
 
@@ -54,7 +55,7 @@ public class ProjectVerifierFactoryTest {
 
   @Test
   @Issue("W-12354025")
-  @Description("Verify that PolicyYamlVerifier validation works after upgrading to snakeyaml 2.0")
+  @Description("We had to change PolicyYamlVerifier.validate() as in snakeyaml 2.0 the constructor of Yaml class has changed. This test verifies that we can correctly validate the yaml after the change and that it is able to read fields from the Yaml file")
   public void verifyValidation() throws ValidationException {
     PolicyYamlVerifier policyYamlVerifier =
         new PolicyYamlVerifier(this.getClass().getResource("/org/mule/tools/api/verifier").getPath(), "custom.policy.test.yaml");

--- a/mule-packager/src/test/java/org/mule/tools/api/verifier/ProjectVerifierFactoryTest.java
+++ b/mule-packager/src/test/java/org/mule/tools/api/verifier/ProjectVerifierFactoryTest.java
@@ -27,7 +27,6 @@ import java.net.URISyntaxException;
 
 import io.qameta.allure.Issue;
 import io.qameta.allure.Description;
-import jdk.jfr.Description;
 import org.junit.Test;
 import org.junit.Test.None;
 

--- a/mule-packager/src/test/resources/org/mule/tools/api/verifier/custom.policy.test.yaml
+++ b/mule-packager/src/test/resources/org/mule/tools/api/verifier/custom.policy.test.yaml
@@ -1,0 +1,25 @@
+id: http-caching
+name: HTTP Caching
+supportedPoliciesVersions: '>=v1'
+description: Provides caching service for HTTP requests.
+category: Quality of service
+type: system
+resourceLevelSupported: true
+standalone: true
+requiredCharacteristics: []
+providedCharacteristics:
+  - HTTP Caching
+configuration:
+  - propertyName: httpCachingKey
+    name: HTTP Caching Key
+    description: |
+      DataWeave Expression for extracting a key from the request.
+      For reference: https://docs.mulesoft.com/mule4-user-guide/v/4.1/dataweave-variables-context and https://docs.mulesoft.com/mule4-user-guide/v/4.1/about-mule-message
+    type: expression
+    defaultValue: "#[attributes.requestPath]"
+    optional: false
+    type: expression
+    defaultValue: "#[attributes.statusCode < 300]"
+    optional: true
+    sensitive: false
+    allowMultiple: false

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
         <coverageLineLimit>0.99</coverageLineLimit>
         <coverageBranchLimit>0.99</coverageBranchLimit>
         <skipJaCoCoCoverage>${skipTests}</skipJaCoCoCoverage>
+        <allure.version>2.8.1</allure.version>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <mule.distribution.standalone.version>4.4.0</mule.distribution.standalone.version>
         <gson.version>2.8.6</gson.version>
         <guava.version>27.0-jre</guava.version>
-        <snakeyaml.version>1.26</snakeyaml.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <semver4j.version>2.2.0</semver4j.version>
         <semantic.version.version>1.2.0</semantic.version.version>
         <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
In October of 2022, a [critical flaw](https://nvd.nist.gov/vuln/detail/CVE-2022-1471) was found in the SnakeYAML package, which allowed an attacker to benefit from remote code execution by sending malicious YAML content and this content being deserialized by the constructor. Finally, in February 2023, the SnakeYAML 2.0 release was pushed that resolves this flaw, also referred to as [CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471). Let’s break down how this version can help you resolve this critical flaw.