### PR TITLE
W-13830473: fixed CVE-2021-26291 vulnerability due to exchange-mule-maven-plugin version 0.0.17

### DIFF
--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/LifecyclePluginsGAVs.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/LifecyclePluginsGAVs.java
@@ -22,5 +22,5 @@ public class LifecyclePluginsGAVs {
   static final String MAVEN_DEPLOY_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-deploy-plugin:3.0.0";
   static final String MAVEN_SITE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-site-plugin:3.12.1";
 
-  static final String EXCHANGE_PUBLICATION_PLUGIN = EXCHANGE_PLUGIN + ":exchange-mule-maven-plugin:0.0.17";
+  static final String EXCHANGE_PUBLICATION_PLUGIN = EXCHANGE_PLUGIN + ":exchange-mule-maven-plugin:0.0.20";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven.dependency.plugin.version>2.10</maven.dependency.plugin.version>
         <maven.plugin.annotations.version>3.6.0</maven.plugin.annotations.version>
-        <exchange.plugin.version>0.0.17</exchange.plugin.version>
+        <exchange.plugin.version>0.0.20</exchange.plugin.version>
 
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <maven.resources.plugin.version>2.7</maven.resources.plugin.version>


### PR DESCRIPTION
# Summary
Updated dependency to exchange-mule-maven-plugin version:0.0.20 to fix vulnerability CVE-2021-26291



# Type of change

- Task


# Links

- [W-13830473](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001X2u4yYAB/view)
