### PR TITLE
W-14125031: Upgrade Maven plugins bound to the MMP Lifecycle

### DIFF
--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/LifecyclePluginsGAVs.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/model/lifecycle/mapping/project/LifecyclePluginsGAVs.java
@@ -14,13 +14,13 @@ public class LifecyclePluginsGAVs {
   private static final String ORG_APACHE_MAVEN_PLUGINS = "org.apache.maven.plugins";
   private static final String EXCHANGE_PLUGIN = "org.mule.tools.maven";
 
-  static final String MAVEN_RESOURCES_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-resources-plugin:3.3.0";
-  static final String MAVEN_CLEAN_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-clean-plugin:3.2.0";
-  static final String MAVEN_COMPILER_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-compiler-plugin:3.10.1";
-  static final String MAVEN_SUREFIRE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-surefire-plugin:3.0.0-M7";
-  static final String MAVEN_INSTALL_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-install-plugin:3.0.1";
-  static final String MAVEN_DEPLOY_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-deploy-plugin:3.0.0";
-  static final String MAVEN_SITE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-site-plugin:3.12.1";
+  static final String MAVEN_RESOURCES_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-resources-plugin:3.3.1";
+  static final String MAVEN_CLEAN_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-clean-plugin:3.3.1";
+  static final String MAVEN_COMPILER_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-compiler-plugin:3.11.0";
+  static final String MAVEN_SUREFIRE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-surefire-plugin:3.1.2";
+  static final String MAVEN_INSTALL_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-install-plugin:3.1.1";
+  static final String MAVEN_DEPLOY_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-deploy-plugin:3.1.1";
+  static final String MAVEN_SITE_PLUGIN = ORG_APACHE_MAVEN_PLUGINS + ":maven-site-plugin:4.0.0-M8";
 
-  static final String EXCHANGE_PUBLICATION_PLUGIN = EXCHANGE_PLUGIN + ":exchange-mule-maven-plugin:0.0.17";
+  static final String EXCHANGE_PUBLICATION_PLUGIN = EXCHANGE_PLUGIN + ":exchange-mule-maven-plugin:0.0.20";
 }


### PR DESCRIPTION
As we are releasing a new major version of MMP we can take profit of it and upgrade all the plugins versions bound to the lifecycle defined by MMP.

This will provide better compatibility in the future.