### PR TITLE
Support project.getArtifact().getFile()=null

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/model/Deployment.java
+++ b/mule-deployer/src/main/java/org/mule/tools/model/Deployment.java
@@ -55,7 +55,11 @@ public abstract class Deployment {
   }
 
   public void setArtifact(File artifact) {
-    this.artifact = artifact.getPath();
+	if (artifact == null) {
+		this.artifact = null;
+	} else {
+		this.artifact = artifact.getPath();
+	}
   }
 
   public void setArtifact(String artifactPath) {


### PR DESCRIPTION
project.getArtifact().getFile() in setBasicDeploymentValues maybe null.
(In 3.8.x just the File was stored and not the path and so there were no null check necessary)