### PR TITLE
Revert usage of JdkConnectorProvider as it blocks on z/OS

### DIFF
--- a/mule-deployer/src/main/java/org/mule/tools/client/core/AbstractClient.java
+++ b/mule-deployer/src/main/java/org/mule/tools/client/core/AbstractClient.java
@@ -17,7 +17,7 @@ import static org.glassfish.jersey.client.ClientProperties.DEFAULT_CHUNK_SIZE;
 import static org.glassfish.jersey.client.ClientProperties.REQUEST_ENTITY_PROCESSING;
 import static org.glassfish.jersey.client.HttpUrlConnectorProvider.SET_METHOD_WORKAROUND;
 import static org.mule.tools.client.authentication.AuthenticationServiceClient.LOGIN;
-import org.glassfish.jersey.jdk.connector.JdkConnectorProvider;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -138,7 +138,7 @@ public abstract class AbstractClient {
 
   protected WebTarget getTarget(String uri, String path) {
     ClientConfig configuration = new ClientConfig();
-    configuration.connectorProvider(new JdkConnectorProvider());
+    configuration.connectorProvider(new HttpUrlConnectorProvider());
     ClientBuilder builder = ClientBuilder.newBuilder().withConfig(configuration);
 
 


### PR DESCRIPTION
With version 4.1.0 the JdkConnectorProvider was introduced (maybe for JDK17).
But with the JdkConnectorProvider the mule:deploy plugin hangs with our JDK8 z/OS backend:
`OS/390 27.00 04 3931`

Internal request I see via ThreadDump was
https://anypoint.mulesoft.com/accounts/api/v2/oauth2/token
blocking in 

```
Thread [main] (Suspended)	
	owns: org.glassfish.jersey.message.internal.WriterInterceptorExecutor$UnCloseableOutputStream  (id=86)	
	owns: org.mule.tools.client.cloudhub.CloudHubClient  (id=87)	
	sun.misc.Unsafe.park(boolean, long) line: not available [native method]	
	java.util.concurrent.locks.LockSupport.park(java.lang.Object) line: 186	
	java.util.concurrent.CountDownLatch$Sync(java.util.concurrent.locks.AbstractQueuedSynchronizer).parkAndCheckInterrupt() line: 847	
	java.util.concurrent.CountDownLatch$Sync(java.util.concurrent.locks.AbstractQueuedSynchronizer).doAcquireSharedInterruptibly(int) line: 1008	
	java.util.concurrent.CountDownLatch$Sync(java.util.concurrent.locks.AbstractQueuedSynchronizer).acquireSharedInterruptibly(int) line: 1315	
	java.util.concurrent.CountDownLatch.await() line: 242	
	org.glassfish.jersey.jdk.connector.internal.ChunkedBodyOutputStream.doInitialBlocking() line: 249	
	org.glassfish.jersey.jdk.connector.internal.ChunkedBodyOutputStream.write(byte[], int, int) line: 92	
	org.glassfish.jersey.jdk.connector.internal.InterceptingOutputStream.write(byte[], int, int) line: 48	
	org.glassfish.jersey.message.internal.CommittingOutputStream.write(byte[], int, int) line: 200	
	org.glassfish.jersey.message.internal.WriterInterceptorExecutor$UnCloseableOutputStream.write(byte[], int, int) line: 276	
	sun.nio.cs.StreamEncoder.writeBytes() line: 233	

```
[thread-dump.txt](https://github.com/mulesoft/mule-maven-plugin/files/14377936/thread-dump.txt)

In future mule-maven-plugin you should make such things configurable.