### PR TITLE
W-14998627: Add skip no-value property-key exception when the project is artifactType=mule && classifier=mule-plugin

### DIFF
--- a/mule-artifact-it/mule-deployer-it/src/test/java/integration/test/mojo/AbstractDeploymentTest.java
+++ b/mule-artifact-it/mule-deployer-it/src/test/java/integration/test/mojo/AbstractDeploymentTest.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
 public abstract class AbstractDeploymentTest {
 
   private static final String MAVEN_OPTS = "MAVEN_OPTS";
-  private static final String DEFAULT_MULE_VERSION = "4.6.0";
+  private static final String DEFAULT_MULE_VERSION = "4.7.0-SNAPSHOT";
   private static final String MAVEN_OPTS_PROPERTY_KEY = "argLine";
 
   protected static final String DEPLOY_GOAL = "deploy";

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
@@ -49,7 +49,8 @@ public class AstGenerator {
   public AstGenerator(MavenClient mavenClient, String runtimeVersion,
                       Set<Artifact> allDependencies, Path workingDir, ClassRealm classRealm,
                       List<Dependency> directDependencies) {
-    this(mavenClient, runtimeVersion, allDependencies, workingDir, classRealm, directDependencies, true, Classifier.MULE_APPLICATION.toString());
+    this(mavenClient, runtimeVersion, allDependencies, workingDir, classRealm, directDependencies, true,
+         Classifier.MULE_APPLICATION.toString());
   }
 
   public AstGenerator(MavenClient mavenClient, String runtimeVersion,
@@ -88,12 +89,21 @@ public class AstGenerator {
       emptyPropertyResolverBuilder.withoutFailuresIfPropertyNotPresent();
     }
 
-    if (Classifier.MULE_PLUGIN.toString().equals(classifier)){
+    if (Classifier.MULE_PLUGIN.toString().equals(classifier)) {
       emptyPropertyResolverBuilder.withoutFailuresIfPropertyNotPresent();
     }
 
     ConfigurationPropertiesResolver propertiesResolver = emptyPropertyResolverBuilder.build();
     builder.withExtensionModels(extensionModels);
+    //TODO - Delete this try catch when fix W-15556985 is implemented - Runtime Team
+    //See MMP Bug W-14998627 and UserStory W-15554719
+    builder.withPropertyResolver(propertyKey -> {
+      try {
+        return (String) propertiesResolver.resolveValue(propertyKey);
+      } catch (Throwable throwable) {
+        return propertyKey;
+      }
+    });
     builder.withPropertyResolver(propertyKey -> (String) propertiesResolver.resolveValue(propertyKey));
     xmlParser = builder.build();
   }

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
@@ -104,7 +104,6 @@ public class AstGenerator {
         return propertyKey;
       }
     });
-    builder.withPropertyResolver(propertyKey -> (String) propertiesResolver.resolveValue(propertyKey));
     xmlParser = builder.build();
   }
 

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
@@ -11,6 +11,7 @@ import static org.mule.runtime.ast.internal.serialization.json.JsonArtifactAstSe
 
 import org.mule.maven.client.api.MavenClient;
 import org.mule.maven.pom.parser.api.model.BundleDescriptor;
+import org.mule.maven.pom.parser.api.model.Classifier;
 import org.mule.runtime.api.meta.model.ExtensionModel;
 import org.mule.runtime.api.util.Pair;
 import org.mule.runtime.ast.api.ArtifactAst;
@@ -48,12 +49,12 @@ public class AstGenerator {
   public AstGenerator(MavenClient mavenClient, String runtimeVersion,
                       Set<Artifact> allDependencies, Path workingDir, ClassRealm classRealm,
                       List<Dependency> directDependencies) {
-    this(mavenClient, runtimeVersion, allDependencies, workingDir, classRealm, directDependencies, true);
+    this(mavenClient, runtimeVersion, allDependencies, workingDir, classRealm, directDependencies, true, Classifier.MULE_APPLICATION.toString());
   }
 
   public AstGenerator(MavenClient mavenClient, String runtimeVersion,
                       Set<Artifact> allDependencies, Path workingDir, ClassRealm classRealm,
-                      List<Dependency> directDependencies, Boolean asApplication) {
+                      List<Dependency> directDependencies, Boolean asApplication, String classifier) {
     ClassLoader classloader = AstGenerator.class.getClassLoader();
     ExtensionModelLoader loader = ExtensionModelLoaderFactory.createLoader(mavenClient, workingDir, classloader, runtimeVersion);
     Set<ExtensionModel> extensionModels = new HashSet<>();
@@ -78,19 +79,24 @@ public class AstGenerator {
     Set<ExtensionModel> runtimeExtensionModels = loader.getRuntimeExtensionModels();
     extensionModels.addAll(runtimeExtensionModels);
     AstXmlParser.Builder builder = new AstXmlParser.Builder();
-    if (!asApplication) {
-      builder.withArtifactType(ArtifactType.DOMAIN);
-    }
-    builder.withExtensionModels(extensionModels);
-
     // Get a more specific error, so we can discriminate unresolved imports because the importFile has a property of because the
     // file does not exist.
-    ConfigurationPropertiesResolver emptyPropertyResolver = new ConfigurationPropertiesHierarchyBuilder().build();
-    builder.withPropertyResolver(propertyKey -> (String) emptyPropertyResolver.resolveValue(propertyKey));
+    ConfigurationPropertiesHierarchyBuilder emptyPropertyResolverBuilder = new ConfigurationPropertiesHierarchyBuilder();
 
+    if (!asApplication) {
+      builder.withArtifactType(ArtifactType.DOMAIN);
+      emptyPropertyResolverBuilder.withoutFailuresIfPropertyNotPresent();
+    }
+
+    if (Classifier.MULE_PLUGIN.toString().equals(classifier)){
+      emptyPropertyResolverBuilder.withoutFailuresIfPropertyNotPresent();
+    }
+
+    ConfigurationPropertiesResolver propertiesResolver = emptyPropertyResolverBuilder.build();
+    builder.withExtensionModels(extensionModels);
+    builder.withPropertyResolver(propertyKey -> (String) propertiesResolver.resolveValue(propertyKey));
     xmlParser = builder.build();
   }
-
 
   private void removeExtModelIfExists(Set<ExtensionModel> extensionModels, Dependency dependency) {
     extensionModels.removeIf(extension -> extension.getArtifactCoordinates()

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/DefaultExtensionModelLoader.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/DefaultExtensionModelLoader.java
@@ -6,7 +6,7 @@
  */
 package org.mule.tooling.internal;
 
-import static org.mule.runtime.core.api.extension.provider.RuntimeExtensionModelProvider.discoverRuntimeExtensionModels;
+import static org.mule.runtime.extension.api.provider.RuntimeExtensionModelProviderLoaderUtils.discoverRuntimeExtensionModels;
 
 import org.mule.maven.client.api.MavenClient;
 import org.mule.maven.pom.parser.api.model.BundleDescriptor;

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/DefaultExtensionModelService.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/internal/DefaultExtensionModelService.java
@@ -18,7 +18,7 @@ import static org.mule.runtime.core.api.lifecycle.LifecycleUtils.startIfNeeded;
 import static org.mule.runtime.core.api.util.UUID.getUUID;
 import static org.mule.runtime.module.artifact.api.descriptor.ArtifactDescriptorConstants.MULE_LOADER_ID;
 import static org.mule.runtime.module.artifact.activation.api.extension.discovery.ExtensionModelDiscoverer.defaultExtensionModelDiscoverer;
-import static org.mule.runtime.core.api.extension.provider.RuntimeExtensionModelProvider.discoverRuntimeExtensionModels;
+import static org.mule.runtime.extension.api.provider.RuntimeExtensionModelProviderLoaderUtils.discoverRuntimeExtensionModels;
 import static org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor.MULE_ARTIFACT_PATH_INSIDE_JAR;
 import static org.mule.runtime.module.artifact.api.descriptor.ArtifactPluginDescriptor.MULE_PLUGIN_POM;
 import static org.mule.runtime.module.deployment.impl.internal.maven.AbstractMavenClassLoaderConfigurationLoader.CLASSLOADER_MODEL_MAVEN_REACTOR_RESOLVER;

--- a/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/AstGeneratorTest.java
+++ b/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/AstGeneratorTest.java
@@ -9,6 +9,7 @@ package org.mule.tooling.internal;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.mule.maven.client.api.MavenClient;
+import org.mule.maven.pom.parser.api.model.Classifier;
 import org.mule.runtime.api.meta.model.parameter.ParameterizedModel;
 import org.mule.runtime.ast.api.ArtifactAst;
 import org.mule.runtime.extension.api.model.construct.ImmutableConstructModel;
@@ -42,7 +43,19 @@ class AstGeneratorTest extends MavenClientTest {
         .isExactlyInstanceOf(ConfigurationException.class);
   }
 
+  @Test
+  void generateASTWithMissingProperty() throws Exception {
+    final Pair<AstGenerator, ArtifactAst> elements = getElements("mule-config3.xml", true,
+            Classifier.MULE_PLUGIN.toString());
+    elements.getLeft().validateAST(elements.getRight());
+  }
+
   private Pair<AstGenerator, ArtifactAst> getElements(String muleConfiguration) {
+    return getElements(muleConfiguration, true,
+                       Classifier.MULE_APPLICATION.toString());
+  }
+
+  private Pair<AstGenerator, ArtifactAst> getElements(String muleConfiguration, Boolean asApplication, String classifier) {
     try {
       final Path workingPath = Paths.get("src", "test", "resources", "test-project");
       final Path configsBasePath = workingPath.resolve("src/main/mule");
@@ -50,7 +63,8 @@ class AstGeneratorTest extends MavenClientTest {
       final MavenClient client =
           getMavenClientInstance(getMavenConfiguration(m2Repo, getUserSettings(m2Repo), getSettingsSecurity(m2Repo)));
       final AstGenerator generator =
-          new AstGenerator(client, "4.3.0", Collections.emptySet(), workingPath, null, Collections.emptyList());
+          new AstGenerator(client, "4.3.0", Collections.emptySet(), workingPath, null, Collections.emptyList(), asApplication,
+                           classifier);
       final ArtifactAst artifact =
           generator.generateAST(Collections.singletonList(configsBasePath.resolve(muleConfiguration).toFile().getAbsolutePath()),
                                 configsBasePath);

--- a/mule-extension-model-loader/src/test/resources/test-project/src/main/mule/mule-config.xml
+++ b/mule-extension-model-loader/src/test/resources/test-project/src/main/mule/mule-config.xml
@@ -1,6 +1,6 @@
 <mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	  xmlns="http://www.mulesoft.org/schema/mule/core"
-	  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+	  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core https://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
 	<flow name="entry-point-1">
 		<set-payload value="original_payload"/>

--- a/mule-extension-model-loader/src/test/resources/test-project/src/main/mule/mule-config2.xml
+++ b/mule-extension-model-loader/src/test/resources/test-project/src/main/mule/mule-config2.xml
@@ -2,7 +2,7 @@
 <mule xmlns="http://www.mulesoft.org/schema/mule/core"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="
-               http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+               http://www.mulesoft.org/schema/mule/core https://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 
     <flow name="onErrorPropagateTypeMatch">
         <set-payload value="#[payload ++ ' apt1']"/>

--- a/mule-extension-model-loader/src/test/resources/test-project/src/main/mule/mule-config3.xml
+++ b/mule-extension-model-loader/src/test/resources/test-project/src/main/mule/mule-config3.xml
@@ -1,0 +1,12 @@
+<mule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	  xmlns="http://www.mulesoft.org/schema/mule/core"
+	  xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+	<!-- Properties -->
+	<configuration-properties file="config/common-config-${mule.env}.yaml"  />
+
+	<flow name="entry-point-${missing-property}">
+		<set-payload value="${new-property}"/>
+	</flow>
+
+</mule>

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/ProcessClassesMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/ProcessClassesMojo.java
@@ -128,7 +128,7 @@ public class ProcessClassesMojo extends AbstractMuleMojo {
     AstGenerator astGenerator = new AstGenerator(getMavenClient(), runtimeVersion.toString(),
                                                  project.getArtifacts(), Paths.get(project.getBuild().getDirectory()),
                                                  descriptor.getClassRealm(), project.getDependencies(),
-                                                 contentResolver.isApplication());
+                                                 contentResolver.isApplication(), getClassifier());
     ProjectStructure projectStructure = new ProjectStructure(projectBaseFolder.toPath(), false);
 
     ArtifactAst artifactAST = astGenerator.generateAST(contentResolver.getConfigs(), projectStructure.getConfigsPath());

--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,10 @@
         <java.target>1.8</java.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dw.version>2.5.0</dw.version>
-        <mule.version>4.6.0</mule.version>
-        <mule.api.version>1.6.0</mule.api.version>
+        <mule.version>4.7.0-SNAPSHOT</mule.version>
+        <mule.api.version>1.7.0-SNAPSHOT</mule.api.version>
         <mule.maven.client.impl.version>2.1.0</mule.maven.client.impl.version>
-        <mule.distribution.standalone.version>4.6.0</mule.distribution.standalone.version>
+        <mule.distribution.standalone.version>4.7.0-SNAPSHOT</mule.distribution.standalone.version>
         <mule.mvel2.version>2.1.9-MULE-020</mule.mvel2.version>
         <gson.version>2.8.9</gson.version>
         <guava.version>32.1.2-jre</guava.version>
@@ -102,6 +102,7 @@
         <maven.dependency.plugin.version>2.10</maven.dependency.plugin.version>
         <maven.plugin.annotations.version>3.8.1</maven.plugin.annotations.version>
         <exchange.plugin.version>0.0.23</exchange.plugin.version>
+        <ast.version>1.3.0-SNAPSHOT</ast.version>
 
         <maven.surefire.plugin.version>3.0.0</maven.surefire.plugin.version>
         <maven.resources.plugin.version>2.7</maven.resources.plugin.version>
@@ -198,17 +199,17 @@
             <dependency>
                 <groupId>org.mule.runtime</groupId>
                 <artifactId>mule-artifact-ast</artifactId>
-                <version>1.2.0</version>
+                <version>${ast.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mule.runtime</groupId>
                 <artifactId>mule-artifact-ast-xml-parser</artifactId>
-                <version>1.2.0</version>
+                <version>${ast.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mule.runtime</groupId>
                 <artifactId>mule-artifact-ast-serialization</artifactId>
-                <version>1.2.0</version>
+                <version>${ast.version}</version>
             </dependency>
             <dependency>
                 <groupId>xml-apis</groupId>


### PR DESCRIPTION
When building with MMP and having a project that is considered and application (see **asApplication**) and is also a mule-plugin (see **Classifier**) then some variables will be set by the final application when using this plugin.
Therefore no error should be caught when building with MMP.
Changes were included in this branch and now the xml is proceses correctly by MMP.
However, when Runtime parsed the properties, it still catch this exception.

Proposed fix: when parsing, take on account the Boolean **failuresIfNotPresent** .

Attached is the full error logs

![image](https://github.com/mulesoft/mule-maven-plugin/assets/97911932/c02be269-b6e4-4904-a942-eb940f727711)

**** 
[logs showing error in Runtime repo.txt](https://github.com/mulesoft/mule-maven-plugin/files/15026206/logs.showing.error.in.Runtime.repo.txt)
