### PR TITLE
W-14998627: Mule Application plugin with unresolved property should not fail

### DIFF
--- a/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/ProcessClassesMojoTest.java
+++ b/mule-artifact-it/mule-packager-it/src/test/java/integration/test/mojo/ProcessClassesMojoTest.java
@@ -196,4 +196,13 @@ public class ProcessClassesMojoTest extends MojoTest implements SettingsConfigur
 
     assertThat(artifactAstTargetFile.exists(), is(true));
   }
+
+  @Test
+  public void astGenerationApplicationPluginWithUnresolvedPropertiesShouldNotFail() throws Exception {
+    projectBaseDirectory =
+        ProjectFactory.createProjectBaseDir("mule-application-plugin-with-unresolved-properties", this.getClass());
+    verifier = buildVerifier(projectBaseDirectory);
+    verifier.executeGoal(GOAL);
+    verifier.verifyErrorFreeLog();
+  }
 }

--- a/mule-artifact-it/mule-packager-it/src/test/resources/mule-application-plugin-with-unresolved-properties/mule-artifact.json
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/mule-application-plugin-with-unresolved-properties/mule-artifact.json
@@ -1,0 +1,3 @@
+{
+  "minMuleVersion": "4.4.0"
+}

--- a/mule-artifact-it/mule-packager-it/src/test/resources/mule-application-plugin-with-unresolved-properties/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/mule-application-plugin-with-unresolved-properties/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+	<artifactId>mule-application-plugin-with-unresolved-properties</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>mule-application</packaging>
+
+	<name>mule-application-plugin-with-unresolved-properties</name>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.2.0</version>
+			</plugin>
+			<plugin>
+				<groupId>org.mule.tools.maven</groupId>
+				<artifactId>mule-maven-plugin</artifactId>
+				<version>${muleMavenPluginVersion}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<classifier>mule-plugin</classifier>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/mule-application-plugin-with-unresolved-properties/src/main/mule/mule-application-plugin-with-unresolved-properties.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/mule-application-plugin-with-unresolved-properties/src/main/mule/mule-application-plugin-with-unresolved-properties.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+	<!-- Properties -->
+	<configuration-properties file="config/common-config-${missing-property-1}.yaml" doc:description="common-config-${missing-property-2}.yaml" />
+	<import file="${env.dependant}"/>
+	
+</mule>

--- a/mule-artifact-it/mule-packager-it/src/test/resources/test-relative-path/pom.xml
+++ b/mule-artifact-it/mule-packager-it/src/test/resources/test-relative-path/pom.xml
@@ -23,7 +23,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<app.runtime>4.3.0-20210622</app.runtime>
-		<mule.maven.plugin.version>4.1.1-SNAPSHOT</mule.maven.plugin.version>
+		<mule.maven.plugin.version>4.2.0-SNAPSHOT</mule.maven.plugin.version>
 	</properties>
 
 	<build>

--- a/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
+++ b/mule-extension-model-loader/src/main/java/org/mule/tooling/api/AstGenerator.java
@@ -81,22 +81,19 @@ public class AstGenerator {
     extensionModels.addAll(runtimeExtensionModels);
     AstXmlParser.Builder builder = new AstXmlParser.Builder();
     ConfigurationPropertiesHierarchyBuilder emptyPropertyResolverBuilder = new ConfigurationPropertiesHierarchyBuilder();
-    ConfigurationPropertiesResolver propertiesResolver = emptyPropertyResolverBuilder.build();
 
     if (!asApplication) {
       builder.withArtifactType(ArtifactType.DOMAIN);
     }
 
-    if (!asApplication || Classifier.MULE_PLUGIN.toString().equals(classifier)) {
-      emptyPropertyResolverBuilder.withoutFailuresIfPropertyNotPresent();
-    }
-    //TODO - Delete this "else" when fix W-15556985 is implemented - Runtime Team
-    // See MMP Bug W-14998627 and UserStory W-15554719
-    else {
-      builder.withPropertyResolver(propertyKey -> (String) propertiesResolver.resolveValue(propertyKey));
-    }
     builder.withExtensionModels(extensionModels);
 
+    //TODO - Delete this "if-else" when fix W-15556985 is implemented - Runtime Team
+    // See MMP Bug W-14998627 and UserStory W-15554719
+    if (asApplication && !Classifier.MULE_PLUGIN.toString().equals(classifier)) {
+      ConfigurationPropertiesResolver propertiesResolver = emptyPropertyResolverBuilder.build();
+      builder.withPropertyResolver(propertyKey -> (String) propertiesResolver.resolveValue(propertyKey));
+    }
     xmlParser = builder.build();
   }
 

--- a/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/MavenClientTest.java
+++ b/mule-extension-model-loader/src/test/java/org/mule/tooling/internal/MavenClientTest.java
@@ -21,6 +21,7 @@ import org.mule.maven.client.api.model.RemoteRepository;
 import org.mule.maven.client.internal.MuleMavenClient;
 
 public abstract class MavenClientTest {
+
   public static final String USER_HOME_PROP = "user.home";
   public static final String M2_DIR = ".m2";
   public static final String M2_HOME = "M2_HOME";
@@ -90,9 +91,10 @@ public abstract class MavenClientTest {
     return mavenConfigurationBuilder;
   }
 
-  private void configureMavenCentralRepo(MavenConfiguration.MavenConfigurationBuilder mavenConfigurationBuilder) throws MalformedURLException {
+  private void configureMavenCentralRepo(MavenConfiguration.MavenConfigurationBuilder mavenConfigurationBuilder)
+      throws MalformedURLException {
     mavenConfigurationBuilder.remoteRepository(RemoteRepository.newRemoteRepositoryBuilder().id("central")
-      .url(new URL("https://repo.maven.apache.org/maven2/")).build());
+        .url(new URL("https://repo.maven.apache.org/maven2/")).build());
   }
 
   public MavenClient getMavenClientInstance(MavenConfiguration.MavenConfigurationBuilder configurationBuilder) {

--- a/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/ProcessClassesMojo.java
+++ b/mule-maven-plugin/src/main/java/org/mule/tools/maven/mojo/ProcessClassesMojo.java
@@ -128,7 +128,7 @@ public class ProcessClassesMojo extends AbstractMuleMojo {
     AstGenerator astGenerator = new AstGenerator(getMavenClient(), runtimeVersion.toString(),
                                                  project.getArtifacts(), Paths.get(project.getBuild().getDirectory()),
                                                  descriptor.getClassRealm(), project.getDependencies(),
-                                                 contentResolver.isApplication());
+                                                 contentResolver.isApplication(), getClassifier());
     ProjectStructure projectStructure = new ProjectStructure(projectBaseFolder.toPath(), false);
 
     ArtifactAst artifactAST = astGenerator.generateAST(contentResolver.getConfigs(), projectStructure.getConfigsPath());

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.mule.tools.maven</groupId>
     <artifactId>mule-artifact-tools</artifactId>
-    <version>4.2.0-SNAPSHOT</version>
+    <version>4.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Mule Artifact Tools</name>


### PR DESCRIPTION
[W-14998627](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001jkagJYAQ/view)


When building with MMP and having a project that is considered an application (see asApplication) and is also a mule-plugin (see Classifier), the final application will set some variables when using this plugin.
Therefore no error should be caught when building with MMP.
An integration test was implemented that reproduces the Bug issue.

New bug for Runtime, to implement fix: [W-15556985](https://gus.lightning.force.com/a07EE00001pKJUKYA4)
New user.story for MMP to remove temporary MMP fix when Runtime fix is implemented: [W-15554719](https://gus.lightning.force.com/a07EE00001pJKzwYAG)

Integrations test error before implementing MMP fix with if-else cause:
![test result before MMP fix with try catch](https://github.com/mulesoft/mule-maven-plugin/assets/97911932/afe44fc9-fbce-429c-8fd4-2800fdf4e41e)

Final Build :
![Uploading build success for PR.png…]()




