### PR TITLE
W-16483490: update GSON from 2.8.9 to  2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <mule.maven.client.impl.version>2.2.0</mule.maven.client.impl.version>
         <mule.distribution.standalone.version>4.7.0</mule.distribution.standalone.version>
         <mule.mvel2.version>2.1.9-MULE-020</mule.mvel2.version>
-        <gson.version>2.8.9</gson.version>
+        <gson.version>2.11.0</gson.version>
         <guava.version>32.1.2-jre</guava.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <semver4j.version>3.1.0</semver4j.version>


### PR DESCRIPTION
MMP pom Gson version has been updated from version 2.8.9 to 2.11.0. 

Build Success Java 8 Maven 3.8.4:


Build Success Java 11 Maven 3.8.8:


Build Success Java 17 Maven 3.9.4:
