### PR TITLE
W-16461385-W-16518212 dw version update and TD remove log4j dependency

### DIFF
--- a/mule-classloader-model/pom.xml
+++ b/mule-classloader-model/pom.xml
@@ -38,10 +38,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <java.source>1.8</java.source>
         <java.target>1.8</java.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dw.version>2.5.0</dw.version>
+        <dw.version>2.7.2</dw.version>
         <mule.version>4.7.2</mule.version>
         <mule.api.version>1.7.2</mule.api.version>
         <mule.maven.client.impl.version>2.2.2</mule.maven.client.impl.version>


### PR DESCRIPTION
Dataweave version updated from 2.5.0 to 2.7.2 
<img width="575" alt="Dataweave Version from Runtime 4 7 2 configs" src="https://github.com/user-attachments/assets/ea766d1f-ace7-4f73-815f-3bedf33eb3e1">

TD-0216018 : Remove log4j dependencies from mule-classloader-model
https://gus.lightning.force.com/lightning/r/ADM_Team_Dependency__c/a0nEE000000bo97YAA/view

Integration Tests run correctly:
<img width="746" alt="Screenshot 2024-08-23 at 5 46 03 PM" src="https://github.com/user-attachments/assets/effeaebe-2c8e-40d7-b472-66c1dfdd6525">
