### PR TITLE
W-17089835: update maven default value in another jenkins files

### DIFF
--- a/integrationTests-Windows.jenkinsfile
+++ b/integrationTests-Windows.jenkinsfile
@@ -4,7 +4,7 @@
 properties([
     parameters([
         string(name: 'JDK', defaultValue: "JDK8", description: 'JDK Version to be used'),
-        string(name: 'maven', defaultValue: "M3", description: 'Maven version to be used')
+        string(name: 'maven', defaultValue: "Maven-3.9.4", description: 'Maven version to be used')
     ]),
 ])
 

--- a/integrationTests.jenkinsfile
+++ b/integrationTests.jenkinsfile
@@ -4,7 +4,7 @@
 properties([
     parameters([
         string(name: 'JDK', defaultValue: "JDK8", description: 'JDK Version to be used'),
-        string(name: 'maven', defaultValue: "M3", description: 'Maven version to be used')
+        string(name: 'maven', defaultValue: "Maven-3.9.4", description: 'Maven version to be used')
     ]),
 ])
 

--- a/integrationTestsJDK11.jenkinsfile
+++ b/integrationTestsJDK11.jenkinsfile
@@ -3,7 +3,7 @@
 
 properties([
     parameters([
-        string(name: 'maven', defaultValue: "M3", description: 'Maven version to be used')
+        string(name: 'maven', defaultValue: "Maven-3.9.4", description: 'Maven version to be used')
     ]),
 ])
 


### PR DESCRIPTION
Update maven default version to "Maven-3.9.4", so that integration tests at Jenkins run ok
Updating the maven version, it started to run successfully:
![image](https://github.com/user-attachments/assets/0e352602-474a-4013-820a-1eaf9661a66d)
